### PR TITLE
claude-3.7-sonnet with thinking, refs #14

### DIFF
--- a/llm_anthropic.py
+++ b/llm_anthropic.py
@@ -309,7 +309,9 @@ class ClaudeMessages(_Shared, llm.KeyModel):
         client = Anthropic(api_key=self.get_key(key))
         kwargs = self.build_kwargs(prompt, conversation)
         prefill_text = self.prefill_text(prompt)
-        thinking_delimiter = prompt.options.thinking_delimiter if self.supports_thinking else None
+        thinking_delimiter = (
+            prompt.options.thinking_delimiter if self.supports_thinking else None
+        )
         if thinking_delimiter is None:
             thinking_delimiter = DEFAULT_THINKING_DELIMITER
         if stream:
@@ -326,9 +328,13 @@ class ClaudeMessages(_Shared, llm.KeyModel):
                             was_thinking = False
                             yield thinking_delimiter
                         yield chunk.delta.text
-                    elif self.supports_thinking and prompt.options.show_thinking and (
-                        chunk.type == "content_block_delta"
-                        and chunk.delta.type == "thinking_delta"
+                    elif (
+                        self.supports_thinking
+                        and prompt.options.show_thinking
+                        and (
+                            chunk.type == "content_block_delta"
+                            and chunk.delta.type == "thinking_delta"
+                        )
                     ):
                         was_thinking = True
                         yield chunk.delta.thinking

--- a/llm_anthropic.py
+++ b/llm_anthropic.py
@@ -309,7 +309,7 @@ class ClaudeMessages(_Shared, llm.KeyModel):
         client = Anthropic(api_key=self.get_key(key))
         kwargs = self.build_kwargs(prompt, conversation)
         prefill_text = self.prefill_text(prompt)
-        thinking_delimiter = prompt.options.thinking_delimiter
+        thinking_delimiter = prompt.options.thinking_delimiter if self.supports_thinking else None
         if thinking_delimiter is None:
             thinking_delimiter = DEFAULT_THINKING_DELIMITER
         if stream:
@@ -326,7 +326,7 @@ class ClaudeMessages(_Shared, llm.KeyModel):
                             was_thinking = False
                             yield thinking_delimiter
                         yield chunk.delta.text
-                    elif prompt.options.show_thinking and (
+                    elif self.supports_thinking and prompt.options.show_thinking and (
                         chunk.type == "content_block_delta"
                         and chunk.delta.type == "thinking_delta"
                     ):

--- a/llm_anthropic.py
+++ b/llm_anthropic.py
@@ -271,9 +271,7 @@ class _Shared:
             prompt.options.thinking = True
         if self.supports_thinking and prompt.options.thinking:
             budget_tokens = prompt.options.thinking_budget or DEFAULT_THINKING_TOKENS
-            kwargs["extra_body"] = {
-                "thinking": {"type": "enabled", "budget_tokens": budget_tokens}
-            }
+            kwargs["thinking"] = {"type": "enabled", "budget_tokens": budget_tokens}
         if prompt.options.user_id:
             kwargs["metadata"] = {"user_id": prompt.options.user_id}
 

--- a/llm_anthropic.py
+++ b/llm_anthropic.py
@@ -380,6 +380,7 @@ class AsyncClaudeMessagesLong(AsyncClaudeMessages):
 
 
 class ClaudeOptionsWithThinking(ClaudeOptions):
+    max_tokens: Optional[int] = long_field
     thinking: Optional[bool] = Field(
         description="Enable thinking mode",
         default=None,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ classifiers = [
 ]
 dependencies = [
     "llm>=0.22",
-    "anthropic>=0.45.2",
+    "anthropic>=0.47.0",
 ]
 
 [project.urls]


### PR DESCRIPTION
Refs:
- #14

Needed:
- [x] Design for the options - `thinking`, `thinking_budget`, `show_thinking` and `thinking_delimiter`
- [x] Sync streaming mode
- [ ] Actually ditch `show_thinking` and `thinking_delimiter` for the moment - see https://github.com/simonw/llm-anthropic/issues/14#issuecomment-2680285848
- [ ] Sync no-streaming mode
- [x] Async streaming mode
- [ ] Async no-streaming mode
- [ ] Tests
- [ ] Docs, including Python docs on how to access thinking tokens via JSON
- [ ] "Include the beta header `output-128k-2025-02-19` in your API request to increase the maximum output token length to 128k tokens for Claude 3.7 Sonnet" from https://docs.anthropic.com/en/docs/about-claude/models/all-models#model-comparison-table
