### PR TITLE
Add support for Claude 4.6 models with adaptive thinking

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ venv
 .vscode
 dist
 build
+uv.lock

--- a/demo.md
+++ b/demo.md
@@ -1,0 +1,140 @@
+# Claude 4.6 Models in llm-anthropic
+
+*2026-02-17T21:32:54Z by Showboat 0.6.0*
+<!-- showboat-id: aa3e535d-4134-4254-89fe-c1d1149d9ef3 -->
+
+This document demonstrates the newly added Claude Opus 4.6 and Sonnet 4.6 models in the llm-anthropic plugin, covering adaptive thinking, the GA effort parameter, structured outputs, web search, and breaking changes like prefill removal.
+
+## Listing the new models
+
+Both models are registered with dot-notation aliases for convenience.
+
+```bash
+uv run llm models | grep "4\.6"
+```
+
+```output
+Anthropic Messages: anthropic/claude-opus-4-6 (aliases: claude-opus-4.6)
+Anthropic Messages: anthropic/claude-sonnet-4-6 (aliases: claude-sonnet-4.6)
+```
+
+## Basic prompting with Sonnet 4.6
+
+Sonnet 4.6 is the fastest of the two new models. Here it responds to a simple prompt.
+
+```bash
+uv run llm -m claude-sonnet-4.6 "Two names for a pet pelican, be brief"
+```
+
+```output
+**Pete** or **Scoop**
+```
+
+## Structured outputs (schema)
+
+4.6 models use the new `output_config.format` API for structured outputs — no beta header required. The `--schema` flag generates JSON conforming to the given schema.
+
+```bash
+uv run llm -m claude-sonnet-4.6 --schema 'name,age int,bio: one sentence' 'invent a dog'
+```
+
+```output
+{"name":"Biscuit McWoofington","age":4,"bio":"Biscuit is a scruffy golden retriever mix who spends his days chasing squirrels, stealing socks, and melting hearts with his lopsided grin."}
+```
+
+## Adaptive thinking
+
+4.6 models use adaptive thinking (`thinking: {type: "adaptive"}`) instead of the old manual budget mode. Claude dynamically decides when and how much to think. Enabled with `-o thinking 1`.
+
+```bash
+uv run llm -m claude-sonnet-4.6 -o thinking 1 "What is the square root of 97 to 3 decimal places?"
+```
+
+```output
+## √97 = **9.849**
+
+**Working it out:**
+
+- 9.8² = 96.04
+- 9.9² = 98.01 → so √97 is between 9.8 and 9.9
+
+Narrowing down:
+- 9.84² = 96.8256
+- 9.85² = 97.0225 → so √97 is between 9.84 and 9.85
+
+Further refinement:
+- 9.848² ≈ 96.9834
+- 9.849² ≈ 97.0028 → so √97 is between 9.848 and 9.849
+
+Since √97 ≈ 9.84886..., rounded to 3 decimal places = **9.849**
+```
+
+We can confirm the model used thinking by inspecting the response logs:
+
+```bash
+uv run llm logs --json -c | python3 -c "import sys,json; d=json.load(sys.stdin); types=[b['type'] for b in d[0]['response_json']['content']]; print('Content block types:', types)"
+```
+
+```output
+Content block types: ['thinking', 'text']
+```
+
+## Effort parameter (GA, no beta header)
+
+On 4.6 models, the effort parameter is generally available and works independently of thinking. This means you can control token spend without enabling extended thinking. The effort parameter accepts `low`, `medium`, `high`, or `max` (Opus 4.6 only).
+
+```bash
+uv run llm -m claude-sonnet-4.6 -o thinking_effort low "What is the capital of France?"
+```
+
+```output
+The capital of France is **Paris**.
+```
+
+## Breaking change: prefill removal
+
+Prefilling assistant messages (setting the start of the response) is not supported on 4.6 models. The plugin catches this early with a clear error rather than letting the API return a 400.
+
+```bash
+uv run llm -m claude-sonnet-4.6 -o prefill '{' 'Return JSON' 2>&1 || true
+```
+
+```output
+Error: Prefilling assistant messages is not supported by claude-sonnet-4-6. Use structured outputs or system prompt instructions instead.
+```
+
+## Max effort is Opus 4.6 only
+
+The new `max` effort level provides the absolute highest capability but is restricted to Opus 4.6. Attempting it on Sonnet 4.6 raises an error.
+
+```bash
+uv run llm -m claude-sonnet-4.6 -o thinking_effort max 'Hello' 2>&1 || true
+```
+
+```output
+Error: thinking_effort='max' is only supported by claude-opus-4-6
+```
+
+## Opus 4.6
+
+Opus 4.6 is the most capable model, with 128K max output tokens and support for `max` effort.
+
+```bash
+uv run llm -m claude-opus-4.6 "One fun fact about pelicans, one sentence"
+```
+
+```output
+Pelicans have a pouch beneath their bill that can hold up to 3 gallons of water, which they use to scoop up fish before draining the water and swallowing their catch.
+```
+
+## Web search
+
+Both 4.6 models support web search, letting Claude access real-time information.
+
+```bash
+uv run llm -m claude-sonnet-4.6 -o web_search 1 "What day of the week is it today?"
+```
+
+```output
+Today is **Monday, February 17, 2026**.
+```

--- a/llm_anthropic.py
+++ b/llm_anthropic.py
@@ -15,6 +15,7 @@ class ThinkingEffort(str, enum.Enum):
     LOW = "low"
     MEDIUM = "medium"
     HIGH = "high"
+    MAX = "max"
 
 
 @llm.hookimpl
@@ -227,6 +228,54 @@ def register_models(register):
         ),
         aliases=("claude-opus-4.5",),
     )
+    # claude-opus-4-6
+    register(
+        ClaudeMessages(
+            "claude-opus-4-6",
+            supports_pdf=True,
+            supports_thinking=True,
+            supports_thinking_effort=True,
+            supports_adaptive_thinking=True,
+            supports_web_search=True,
+            use_structured_outputs=True,
+            default_max_tokens=8192,
+        ),
+        AsyncClaudeMessages(
+            "claude-opus-4-6",
+            supports_pdf=True,
+            supports_thinking=True,
+            supports_thinking_effort=True,
+            supports_adaptive_thinking=True,
+            supports_web_search=True,
+            use_structured_outputs=True,
+            default_max_tokens=8192,
+        ),
+        aliases=("claude-opus-4.6",),
+    )
+    # claude-sonnet-4-6
+    register(
+        ClaudeMessages(
+            "claude-sonnet-4-6",
+            supports_pdf=True,
+            supports_thinking=True,
+            supports_thinking_effort=True,
+            supports_adaptive_thinking=True,
+            supports_web_search=True,
+            use_structured_outputs=True,
+            default_max_tokens=8192,
+        ),
+        AsyncClaudeMessages(
+            "claude-sonnet-4-6",
+            supports_pdf=True,
+            supports_thinking=True,
+            supports_thinking_effort=True,
+            supports_adaptive_thinking=True,
+            supports_web_search=True,
+            use_structured_outputs=True,
+            default_max_tokens=8192,
+        ),
+        aliases=("claude-sonnet-4.6",),
+    )
 
 
 class ClaudeOptions(llm.Options):
@@ -428,6 +477,7 @@ class _Shared:
 
     supports_thinking = False
     supports_thinking_effort = False
+    supports_adaptive_thinking = False
     supports_schema = True
     supports_tools = True
     supports_web_search = False
@@ -443,6 +493,7 @@ class _Shared:
         supports_pdf=False,
         supports_thinking=False,
         supports_thinking_effort=False,
+        supports_adaptive_thinking=False,
         supports_web_search=False,
         use_structured_outputs=False,
         default_max_tokens=None,
@@ -470,6 +521,8 @@ class _Shared:
         if supports_thinking_effort:
             self.supports_thinking_effort = True
             self.Options = ClaudeOptionsWithThinkingEffort
+        if supports_adaptive_thinking:
+            self.supports_adaptive_thinking = True
         if default_max_tokens is not None:
             self.default_max_tokens = default_max_tokens
         self.supports_web_search = supports_web_search
@@ -615,6 +668,11 @@ class _Shared:
 
         # Add prefill if specified
         if prompt.options.prefill:
+            if self.supports_adaptive_thinking:
+                raise ValueError(
+                    f"Prefilling assistant messages is not supported by {self.claude_model_id}. "
+                    f"Use structured outputs or system prompt instructions instead."
+                )
             prefill_content = [{"type": "text", "text": prompt.options.prefill}]
             messages.append({"role": "assistant", "content": prefill_content})
 
@@ -631,7 +689,8 @@ class _Shared:
             raise ValueError(
                 f"Web search is not supported by model {self.model_id}. "
                 f"Supported models include: claude-3.5-sonnet-latest, claude-3.5-haiku-latest, "
-                f"claude-3.7-sonnet-latest, claude-4-opus, claude-4-sonnet, claude-opus-4.1"
+                f"claude-3.7-sonnet-latest, claude-4-opus, claude-4-sonnet, claude-opus-4.1, "
+                f"claude-opus-4.6, claude-sonnet-4.6"
             )
 
         kwargs = {
@@ -662,21 +721,47 @@ class _Shared:
         thinking_effort_enabled = (
             self.supports_thinking_effort and prompt.options.thinking_effort
         )
-        if self.supports_thinking and (
-            prompt.options.thinking
-            or prompt.options.thinking_budget
-            or thinking_effort_enabled
-        ):
+
+        # Determine if thinking should be activated
+        thinking_requested = False
+        if self.supports_thinking:
+            thinking_requested = prompt.options.thinking or prompt.options.thinking_budget
+            # On pre-GA effort models (Opus 4.5), effort implies thinking
+            if thinking_effort_enabled and not self.supports_adaptive_thinking:
+                thinking_requested = True
+
+        if self.supports_thinking and thinking_requested:
             prompt.options.thinking = True
-            if thinking_effort_enabled:
-                kwargs["output_config"] = {
-                    "effort": prompt.options.thinking_effort.value
+            if prompt.options.thinking_budget:
+                # Explicit budget = manual mode (deprecated on 4.6 but still works)
+                kwargs["thinking"] = {
+                    "type": "enabled",
+                    "budget_tokens": prompt.options.thinking_budget,
                 }
+            elif self.supports_adaptive_thinking:
+                # 4.6 models default to adaptive thinking
+                kwargs["thinking"] = {"type": "adaptive"}
             else:
-                budget_tokens = (
-                    prompt.options.thinking_budget or DEFAULT_THINKING_TOKENS
-                )
-                kwargs["thinking"] = {"type": "enabled", "budget_tokens": budget_tokens}
+                # Pre-4.6 models: enabled with default budget
+                budget_tokens = DEFAULT_THINKING_TOKENS
+                kwargs["thinking"] = {
+                    "type": "enabled",
+                    "budget_tokens": budget_tokens,
+                }
+
+        # Handle effort in output_config
+        if thinking_effort_enabled:
+            if prompt.options.thinking_effort == ThinkingEffort.MAX:
+                if not (
+                    self.supports_adaptive_thinking
+                    and "opus" in self.claude_model_id
+                ):
+                    raise ValueError(
+                        "thinking_effort='max' is only supported by claude-opus-4-6"
+                    )
+            kwargs.setdefault("output_config", {})["effort"] = (
+                prompt.options.thinking_effort.value
+            )
 
         max_tokens = self.default_max_tokens
         if prompt.options.max_tokens is not None:
@@ -691,9 +776,17 @@ class _Shared:
 
         # Determine which beta headers to use
         betas = []
-        if "output_config" in kwargs:
+
+        # Effort beta: only for pre-GA models (e.g., Opus 4.5)
+        if (
+            "output_config" in kwargs
+            and "effort" in kwargs.get("output_config", {})
+            and not self.supports_adaptive_thinking
+        ):
             betas.append("effort-2025-11-24")
-        if max_tokens > 64000:
+
+        # 128K output beta: not needed for 4.6 models
+        if max_tokens > 64000 and not self.supports_adaptive_thinking:
             betas.append("output-128k-2025-02-19")
             if "thinking" in kwargs:
                 kwargs["extra_body"] = {"thinking": kwargs.pop("thinking")}
@@ -702,13 +795,19 @@ class _Shared:
         use_structured_outputs = prompt.schema and self.use_structured_outputs
 
         if use_structured_outputs:
-            # Use new structured outputs mechanism
-            betas.append("structured-outputs-2025-11-13")
-            # Transform schema to ensure it meets structured output requirements
-            kwargs["output_format"] = {
-                "type": "json_schema",
-                "schema": transform_schema(prompt.schema),
-            }
+            if self.supports_adaptive_thinking:
+                # 4.6: output_config.format, no beta header
+                kwargs.setdefault("output_config", {})["format"] = {
+                    "type": "json_schema",
+                    "schema": transform_schema(prompt.schema),
+                }
+            else:
+                # Pre-4.6: output_format with beta header
+                betas.append("structured-outputs-2025-11-13")
+                kwargs["output_format"] = {
+                    "type": "json_schema",
+                    "schema": transform_schema(prompt.schema),
+                }
 
         if betas:
             kwargs["betas"] = betas
@@ -808,9 +907,10 @@ class ClaudeMessages(_Shared, llm.KeyModel):
         else:
             messages_client = client.messages
 
-        # For structured outputs, convert JSON schema to Pydantic model for stream()
+        # For structured outputs with output_format (pre-4.6), convert JSON schema
+        # to Pydantic model for beta stream(). output_config.format (4.6) uses raw
+        # JSON schema dict directly.
         if "output_format" in kwargs and stream:
-            # Extract the schema and convert to Pydantic model
             schema = kwargs["output_format"]["schema"]
             pydantic_model = json_schema_to_model(schema)
             kwargs["output_format"] = pydantic_model
@@ -856,9 +956,10 @@ class AsyncClaudeMessages(_Shared, llm.AsyncKeyModel):
             messages_client = client.messages
         prefill_text = self.prefill_text(prompt)
 
-        # For structured outputs, convert JSON schema to Pydantic model for stream()
+        # For structured outputs with output_format (pre-4.6), convert JSON schema
+        # to Pydantic model for beta stream(). output_config.format (4.6) uses raw
+        # JSON schema dict directly.
         if "output_format" in kwargs and stream:
-            # Extract the schema and convert to Pydantic model
             schema = kwargs["output_format"]["schema"]
             pydantic_model = json_schema_to_model(schema)
             kwargs["output_format"] = pydantic_model

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ requires-python = ">=3.10"
 classifiers = []
 dependencies = [
     "llm>=0.26",
-    "anthropic>=0.75",
+    "anthropic>=0.80",
     "json-schema-to-pydantic",
 ]
 

--- a/tests/cassettes/test_anthropic/test_async_prompt.yaml
+++ b/tests/cassettes/test_anthropic/test_async_prompt.yaml
@@ -18,17 +18,19 @@ interactions:
       host:
       - api.anthropic.com
       user-agent:
-      - AsyncAnthropic/Python 0.73.0
+      - AsyncAnthropic/Python 0.80.0
       x-stainless-arch:
       - arm64
       x-stainless-async:
       - async:asyncio
+      x-stainless-helper-method:
+      - stream
       x-stainless-lang:
       - python
       x-stainless-os:
       - MacOS
       x-stainless-package-version:
-      - 0.73.0
+      - 0.80.0
       x-stainless-read-timeout:
       - '600'
       x-stainless-retry-count:
@@ -47,23 +49,12 @@ interactions:
     body:
       string: 'event: message_start
 
-        data: {"type":"message_start","message":{"model":"claude-sonnet-4-5-20250929","id":"msg_01RSrER3RvH5a1GvAeMuTVfk","type":"message","role":"assistant","content":[],"stop_reason":null,"stop_sequence":null,"usage":{"input_tokens":17,"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"cache_creation":{"ephemeral_5m_input_tokens":0,"ephemeral_1h_input_tokens":0},"output_tokens":1,"service_tier":"standard"}}            }
+        data: {"type":"message_start","message":{"model":"claude-sonnet-4-5-20250929","id":"msg_01KHTDfhXSbjLyGST1qLVLV3","type":"message","role":"assistant","content":[],"stop_reason":null,"stop_sequence":null,"usage":{"input_tokens":17,"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"cache_creation":{"ephemeral_5m_input_tokens":0,"ephemeral_1h_input_tokens":0},"output_tokens":1,"service_tier":"standard","inference_geo":"not_available"}}   }
 
 
         event: content_block_start
 
-        data: {"type":"content_block_start","index":0,"content_block":{"type":"text","text":""}   }
-
-
-        event: content_block_delta
-
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"-"}     }
-
-
-        event: content_block_delta
-
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"
-        Captain"}        }
+        data: {"type":"content_block_start","index":0,"content_block":{"type":"text","text":""}         }
 
 
         event: ping
@@ -73,23 +64,35 @@ interactions:
 
         event: content_block_delta
 
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"\n-
-        Sc"} }
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"-"}        }
 
 
         event: content_block_delta
 
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"oop"}     }
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"
+        Captain"}           }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"\n-
+        Sc"}      }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"oop"}
+        }
 
 
         event: content_block_stop
 
-        data: {"type":"content_block_stop","index":0            }
+        data: {"type":"content_block_stop","index":0         }
 
 
         event: message_delta
 
-        data: {"type":"message_delta","delta":{"stop_reason":"end_turn","stop_sequence":null},"usage":{"input_tokens":17,"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"output_tokens":10}              }
+        data: {"type":"message_delta","delta":{"stop_reason":"end_turn","stop_sequence":null},"usage":{"input_tokens":17,"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"output_tokens":10}}
 
 
         event: message_stop
@@ -100,15 +103,17 @@ interactions:
         '
     headers:
       CF-RAY:
-      - 99eaefa7dd5c174e-SJC
+      - 9cf92a03de7b7aaf-SJC
       Cache-Control:
       - no-cache
       Connection:
       - keep-alive
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - text/event-stream; charset=utf-8
       Date:
-      - Sat, 15 Nov 2025 01:22:13 GMT
+      - Tue, 17 Feb 2026 23:46:27 GMT
       Server:
       - cloudflare
       Transfer-Encoding:
@@ -122,29 +127,33 @@ interactions:
       anthropic-ratelimit-input-tokens-remaining:
       - '2000000'
       anthropic-ratelimit-input-tokens-reset:
-      - '2025-11-15T01:22:11Z'
+      - '2026-02-17T23:46:26Z'
       anthropic-ratelimit-output-tokens-limit:
       - '400000'
       anthropic-ratelimit-output-tokens-remaining:
       - '400000'
       anthropic-ratelimit-output-tokens-reset:
-      - '2025-11-15T01:22:11Z'
+      - '2026-02-17T23:46:26Z'
+      anthropic-ratelimit-requests-limit:
+      - '20000'
+      anthropic-ratelimit-requests-remaining:
+      - '19999'
+      anthropic-ratelimit-requests-reset:
+      - '2026-02-17T23:46:26Z'
       anthropic-ratelimit-tokens-limit:
       - '2400000'
       anthropic-ratelimit-tokens-remaining:
       - '2400000'
       anthropic-ratelimit-tokens-reset:
-      - '2025-11-15T01:22:11Z'
+      - '2026-02-17T23:46:26Z'
       cf-cache-status:
       - DYNAMIC
       request-id:
-      - req_011CV8oJfFQZxSudWi62YDfh
-      retry-after:
-      - '52'
+      - req_011CYEXr8tVywV7AFBGxgYh2
       strict-transport-security:
       - max-age=31536000; includeSubDomains; preload
       x-envoy-upstream-service-time:
-      - '1955'
+      - '1044'
     status:
       code: 200
       message: OK
@@ -168,17 +177,19 @@ interactions:
       host:
       - api.anthropic.com
       user-agent:
-      - AsyncAnthropic/Python 0.73.0
+      - AsyncAnthropic/Python 0.80.0
       x-stainless-arch:
       - arm64
       x-stainless-async:
       - async:asyncio
+      x-stainless-helper-method:
+      - stream
       x-stainless-lang:
       - python
       x-stainless-os:
       - MacOS
       x-stainless-package-version:
-      - 0.73.0
+      - 0.80.0
       x-stainless-read-timeout:
       - '600'
       x-stainless-retry-count:
@@ -197,23 +208,12 @@ interactions:
     body:
       string: 'event: message_start
 
-        data: {"type":"message_start","message":{"model":"claude-sonnet-4-5-20250929","id":"msg_01Ps4WX7cAj5LbpQuviAGTb4","type":"message","role":"assistant","content":[],"stop_reason":null,"stop_sequence":null,"usage":{"input_tokens":32,"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"cache_creation":{"ephemeral_5m_input_tokens":0,"ephemeral_1h_input_tokens":0},"output_tokens":8,"service_tier":"standard"}}          }
+        data: {"type":"message_start","message":{"model":"claude-sonnet-4-5-20250929","id":"msg_016sMi4YLMSjiUeyi1JQoSJZ","type":"message","role":"assistant","content":[],"stop_reason":null,"stop_sequence":null,"usage":{"input_tokens":32,"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"cache_creation":{"ephemeral_5m_input_tokens":0,"ephemeral_1h_input_tokens":0},"output_tokens":1,"service_tier":"standard","inference_geo":"not_available"}}       }
 
 
         event: content_block_start
 
-        data: {"type":"content_block_start","index":0,"content_block":{"type":"text","text":""}       }
-
-
-        event: content_block_delta
-
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"-
-        Capitaine\n- B"}   }
-
-
-        event: content_block_delta
-
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"ec"}}
+        data: {"type":"content_block_start","index":0,"content_block":{"type":"text","text":""}             }
 
 
         event: ping
@@ -223,48 +223,65 @@ interactions:
 
         event: content_block_delta
 
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"
-        ("}      }
-
-
-        event: content_block_delta
-
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"meaning"}              }
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"-"}   }
 
 
         event: content_block_delta
 
         data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"
-        \"beak\")"}     }
+        Capitaine\n- B"}              }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"ec"}               }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"
+        ("}}
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"b"}               }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"eak)"}}
 
 
         event: content_block_stop
 
-        data: {"type":"content_block_stop","index":0        }
+        data: {"type":"content_block_stop","index":0           }
 
 
         event: message_delta
 
-        data: {"type":"message_delta","delta":{"stop_reason":"end_turn","stop_sequence":null},"usage":{"input_tokens":32,"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"output_tokens":18}             }
+        data: {"type":"message_delta","delta":{"stop_reason":"end_turn","stop_sequence":null},"usage":{"input_tokens":32,"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"output_tokens":16}}
 
 
         event: message_stop
 
-        data: {"type":"message_stop"              }
+        data: {"type":"message_stop"       }
 
 
         '
     headers:
       CF-RAY:
-      - 99eaefb87d1b303f-SJC
+      - 9cf92a0dde6cb8e7-SJC
       Cache-Control:
       - no-cache
       Connection:
       - keep-alive
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - text/event-stream; charset=utf-8
       Date:
-      - Sat, 15 Nov 2025 01:22:16 GMT
+      - Tue, 17 Feb 2026 23:46:29 GMT
       Server:
       - cloudflare
       Transfer-Encoding:
@@ -278,29 +295,33 @@ interactions:
       anthropic-ratelimit-input-tokens-remaining:
       - '2000000'
       anthropic-ratelimit-input-tokens-reset:
-      - '2025-11-15T01:22:14Z'
+      - '2026-02-17T23:46:28Z'
       anthropic-ratelimit-output-tokens-limit:
       - '400000'
       anthropic-ratelimit-output-tokens-remaining:
       - '400000'
       anthropic-ratelimit-output-tokens-reset:
-      - '2025-11-15T01:22:14Z'
+      - '2026-02-17T23:46:28Z'
+      anthropic-ratelimit-requests-limit:
+      - '20000'
+      anthropic-ratelimit-requests-remaining:
+      - '19999'
+      anthropic-ratelimit-requests-reset:
+      - '2026-02-17T23:46:28Z'
       anthropic-ratelimit-tokens-limit:
       - '2400000'
       anthropic-ratelimit-tokens-remaining:
       - '2400000'
       anthropic-ratelimit-tokens-reset:
-      - '2025-11-15T01:22:14Z'
+      - '2026-02-17T23:46:28Z'
       cf-cache-status:
       - DYNAMIC
       request-id:
-      - req_011CV8oJrYocKcxpQQ2Nx3tR
-      retry-after:
-      - '49'
+      - req_011CYEXrFj1gsPp56SV9vzF6
       strict-transport-security:
       - max-age=31536000; includeSubDomains; preload
       x-envoy-upstream-service-time:
-      - '1679'
+      - '1000'
     status:
       code: 200
       message: OK

--- a/tests/cassettes/test_anthropic/test_image_prompt.yaml
+++ b/tests/cassettes/test_anthropic/test_image_prompt.yaml
@@ -18,17 +18,19 @@ interactions:
       host:
       - api.anthropic.com
       user-agent:
-      - Anthropic/Python 0.73.0
+      - Anthropic/Python 0.80.0
       x-stainless-arch:
       - arm64
       x-stainless-async:
       - 'false'
+      x-stainless-helper-method:
+      - stream
       x-stainless-lang:
       - python
       x-stainless-os:
       - MacOS
       x-stainless-package-version:
-      - 0.73.0
+      - 0.80.0
       x-stainless-read-timeout:
       - '600'
       x-stainless-retry-count:
@@ -47,25 +49,12 @@ interactions:
     body:
       string: 'event: message_start
 
-        data: {"type":"message_start","message":{"model":"claude-sonnet-4-5-20250929","id":"msg_015BAr4z2vgXmB2YBmG6mkZy","type":"message","role":"assistant","content":[],"stop_reason":null,"stop_sequence":null,"usage":{"input_tokens":83,"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"cache_creation":{"ephemeral_5m_input_tokens":0,"ephemeral_1h_input_tokens":0},"output_tokens":1,"service_tier":"standard"}}
-        }
+        data: {"type":"message_start","message":{"model":"claude-sonnet-4-5-20250929","id":"msg_015uV9WrrY9nhNRUqWuTcEtm","type":"message","role":"assistant","content":[],"stop_reason":null,"stop_sequence":null,"usage":{"input_tokens":83,"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"cache_creation":{"ephemeral_5m_input_tokens":0,"ephemeral_1h_input_tokens":0},"output_tokens":1,"service_tier":"standard","inference_geo":"not_available"}}    }
 
 
         event: content_block_start
 
-        data: {"type":"content_block_start","index":0,"content_block":{"type":"text","text":""}
-        }
-
-
-        event: content_block_delta
-
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"Re"}            }
-
-
-        event: content_block_delta
-
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"d
-        square"}            }
+        data: {"type":"content_block_start","index":0,"content_block":{"type":"text","text":""}  }
 
 
         event: ping
@@ -75,43 +64,62 @@ interactions:
 
         event: content_block_delta
 
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":",
-        green"}  }
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"Red"}              }
 
 
         event: content_block_delta
 
         data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"
-        square."}  }
+        square"}    }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":",
+        green"}    }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"
+        square"}            }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"."}
+        }
 
 
         event: content_block_stop
 
-        data: {"type":"content_block_stop","index":0         }
+        data: {"type":"content_block_stop","index":0              }
 
 
         event: message_delta
 
-        data: {"type":"message_delta","delta":{"stop_reason":"end_turn","stop_sequence":null},"usage":{"input_tokens":83,"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"output_tokens":9}             }
+        data: {"type":"message_delta","delta":{"stop_reason":"end_turn","stop_sequence":null},"usage":{"input_tokens":83,"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"output_tokens":9}     }
 
 
         event: message_stop
 
-        data: {"type":"message_stop"       }
+        data: {"type":"message_stop"               }
 
 
         '
     headers:
       CF-RAY:
-      - 99eaca1f0e6d69a0-SJC
+      - 9cf926cdcd9eb828-SJC
       Cache-Control:
       - no-cache
       Connection:
       - keep-alive
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - text/event-stream; charset=utf-8
       Date:
-      - Sat, 15 Nov 2025 00:56:36 GMT
+      - Tue, 17 Feb 2026 23:44:16 GMT
       Server:
       - cloudflare
       Transfer-Encoding:
@@ -125,29 +133,33 @@ interactions:
       anthropic-ratelimit-input-tokens-remaining:
       - '1999000'
       anthropic-ratelimit-input-tokens-reset:
-      - '2025-11-15T00:56:34Z'
+      - '2026-02-17T23:44:15Z'
       anthropic-ratelimit-output-tokens-limit:
       - '400000'
       anthropic-ratelimit-output-tokens-remaining:
       - '400000'
       anthropic-ratelimit-output-tokens-reset:
-      - '2025-11-15T00:56:34Z'
+      - '2026-02-17T23:44:15Z'
+      anthropic-ratelimit-requests-limit:
+      - '20000'
+      anthropic-ratelimit-requests-remaining:
+      - '19999'
+      anthropic-ratelimit-requests-reset:
+      - '2026-02-17T23:44:15Z'
       anthropic-ratelimit-tokens-limit:
       - '2400000'
       anthropic-ratelimit-tokens-remaining:
       - '2399000'
       anthropic-ratelimit-tokens-reset:
-      - '2025-11-15T00:56:34Z'
+      - '2026-02-17T23:44:15Z'
       cf-cache-status:
       - DYNAMIC
       request-id:
-      - req_011CV8mML5qnE1Ai9BccNDPd
-      retry-after:
-      - '26'
+      - req_011CYEXgSYrkVjyhx1k5rzxd
       strict-transport-security:
       - max-age=31536000; includeSubDomains; preload
       x-envoy-upstream-service-time:
-      - '1662'
+      - '1270'
     status:
       code: 200
       message: OK

--- a/tests/cassettes/test_anthropic/test_opus_46_adaptive_thinking.yaml
+++ b/tests/cassettes/test_anthropic/test_opus_46_adaptive_thinking.yaml
@@ -1,0 +1,260 @@
+interactions:
+- request:
+    body: '{"max_tokens":8192,"messages":[{"role":"user","content":[{"type":"text","text":"Two
+      names for a pet pelican, be brief"}]}],"model":"claude-opus-4-6","temperature":1.0,"thinking":{"type":"adaptive"},"stream":true}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '212'
+      Content-Type:
+      - application/json
+      Host:
+      - api.anthropic.com
+      User-Agent:
+      - Anthropic/Python 0.79.0
+      X-Stainless-Arch:
+      - x64
+      X-Stainless-Async:
+      - 'false'
+      X-Stainless-Helper-Method:
+      - stream
+      X-Stainless-Lang:
+      - python
+      X-Stainless-OS:
+      - Linux
+      X-Stainless-Package-Version:
+      - 0.79.0
+      X-Stainless-Runtime:
+      - CPython
+      X-Stainless-Runtime-Version:
+      - 3.11.14
+      X-Stainless-Stream-Helper:
+      - messages
+      anthropic-version:
+      - '2023-06-01'
+      x-stainless-read-timeout:
+      - '600'
+      x-stainless-retry-count:
+      - '0'
+      x-stainless-timeout:
+      - NOT_GIVEN
+    method: POST
+    uri: https://api.anthropic.com/v1/messages
+  response:
+    body:
+      string: 'event: message_start
+
+        data: {"type":"message_start","message":{"model":"claude-opus-4-6","id":"msg_016xaB3rMXQHTBuAJvtvxaQx","type":"message","role":"assistant","content":[],"stop_reason":null,"stop_sequence":null,"usage":{"input_tokens":34,"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"cache_creation":{"ephemeral_5m_input_tokens":0,"ephemeral_1h_input_tokens":0},"output_tokens":0,"service_tier":"standard","inference_geo":"global"}}      }
+
+
+        event: content_block_start
+
+        data: {"type":"content_block_start","index":0,"content_block":{"type":"text","text":""}     }
+
+
+        event: ping
+
+        data: {"type": "ping"}
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"\n\n"}              }
+
+
+        event: content_block_stop
+
+        data: {"type":"content_block_stop","index":0      }
+
+
+        event: content_block_start
+
+        data: {"type":"content_block_start","index":1,"content_block":{"type":"thinking","thinking":"","signature":""}   }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":1,"delta":{"type":"thinking_delta","thinking":"Brief"}    }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":1,"delta":{"type":"thinking_delta","thinking":"
+        answer"}     }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":1,"delta":{"type":"thinking_delta","thinking":"
+        with"}    }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":1,"delta":{"type":"thinking_delta","thinking":"
+        two pet"} }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":1,"delta":{"type":"thinking_delta","thinking":"
+        pel"}     }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":1,"delta":{"type":"thinking_delta","thinking":"ican"}          }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":1,"delta":{"type":"thinking_delta","thinking":"
+        names."}   }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":1,"delta":{"type":"thinking_delta","thinking":""}              }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":1,"delta":{"type":"signature_delta","signature":"EtABCkYICxgCKkCVRmhlD4SUFC1JfxwvjOHbkC3CPAIcWq1zn348H+o2blk997x12Vc5JMyLNWxB6/bjLXUlJbHrROizHnvNtDaXEgz6UEiizB6ShSqw9cMaDN3d+Ba0ENx0lUZk7CIwdsIvrlZbePn/CAF9+CeoO/fH53/gbO/WN3Effb0D41XifY7gyfQ8ftQWSLcsH+63KjjJYfLppl3C5/75CQsFv+3XvurDwcdYbguoPM0RDiBHB2JRX/gKF0vzMKik41tZsSGAoENhIz4SWxgB"}          }
+
+
+        event: content_block_stop
+
+        data: {"type":"content_block_stop","index":1         }
+
+
+        event: content_block_start
+
+        data: {"type":"content_block_start","index":2,"content_block":{"type":"text","text":""}             }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":2,"delta":{"type":"text_delta","text":"1"}  }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":2,"delta":{"type":"text_delta","text":".
+        **"}        }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":2,"delta":{"type":"text_delta","text":"Captain"}}
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":2,"delta":{"type":"text_delta","text":"
+        Sc"} }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":2,"delta":{"type":"text_delta","text":"oop"}          }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":2,"delta":{"type":"text_delta","text":"**"}       }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":2,"delta":{"type":"text_delta","text":"\n2.
+        **Gul"}   }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":2,"delta":{"type":"text_delta","text":"let"}      }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":2,"delta":{"type":"text_delta","text":"**"}      }
+
+
+        event: content_block_stop
+
+        data: {"type":"content_block_stop","index":2         }
+
+
+        event: message_delta
+
+        data: {"type":"message_delta","delta":{"stop_reason":"end_turn","stop_sequence":null},"usage":{"input_tokens":34,"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"output_tokens":44}          }
+
+
+        event: message_stop
+
+        data: {"type":"message_stop"}
+
+
+        '
+    headers:
+      CF-RAY:
+      - 9cf7b1b42ccdd130-ORD
+      Cache-Control:
+      - no-cache
+      Connection:
+      - keep-alive
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - text/event-stream; charset=utf-8
+      Date:
+      - Tue, 17 Feb 2026 19:29:35 GMT
+      Server:
+      - cloudflare
+      Transfer-Encoding:
+      - chunked
+      X-Robots-Tag:
+      - none
+      anthropic-organization-id:
+      - b320df16-c763-4455-b901-3f7d54e9a012
+      anthropic-ratelimit-input-tokens-limit:
+      - '2000000'
+      anthropic-ratelimit-input-tokens-remaining:
+      - '2000000'
+      anthropic-ratelimit-input-tokens-reset:
+      - '2026-02-17T19:29:32Z'
+      anthropic-ratelimit-output-tokens-limit:
+      - '400000'
+      anthropic-ratelimit-output-tokens-remaining:
+      - '400000'
+      anthropic-ratelimit-output-tokens-reset:
+      - '2026-02-17T19:29:32Z'
+      anthropic-ratelimit-requests-limit:
+      - '4000'
+      anthropic-ratelimit-requests-remaining:
+      - '3999'
+      anthropic-ratelimit-requests-reset:
+      - '2026-02-17T19:29:32Z'
+      anthropic-ratelimit-tokens-limit:
+      - '2400000'
+      anthropic-ratelimit-tokens-remaining:
+      - '2400000'
+      anthropic-ratelimit-tokens-reset:
+      - '2026-02-17T19:29:32Z'
+      cf-cache-status:
+      - DYNAMIC
+      request-id:
+      - req_011CYECFvaBJJLbgcvbBiR8Q
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains; preload
+      x-envoy-upstream-service-time:
+      - '2639'
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/cassettes/test_anthropic/test_opus_46_prompt.yaml
+++ b/tests/cassettes/test_anthropic/test_opus_46_prompt.yaml
@@ -1,0 +1,187 @@
+interactions:
+- request:
+    body: '{"max_tokens":8192,"messages":[{"role":"user","content":[{"type":"text","text":"Two
+      names for a pet pelican, be brief"}]}],"model":"claude-opus-4-6","temperature":1.0,"stream":true}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '181'
+      Content-Type:
+      - application/json
+      Host:
+      - api.anthropic.com
+      User-Agent:
+      - Anthropic/Python 0.79.0
+      X-Stainless-Arch:
+      - x64
+      X-Stainless-Async:
+      - 'false'
+      X-Stainless-Helper-Method:
+      - stream
+      X-Stainless-Lang:
+      - python
+      X-Stainless-OS:
+      - Linux
+      X-Stainless-Package-Version:
+      - 0.79.0
+      X-Stainless-Runtime:
+      - CPython
+      X-Stainless-Runtime-Version:
+      - 3.11.14
+      X-Stainless-Stream-Helper:
+      - messages
+      anthropic-version:
+      - '2023-06-01'
+      x-stainless-read-timeout:
+      - '600'
+      x-stainless-retry-count:
+      - '0'
+      x-stainless-timeout:
+      - NOT_GIVEN
+    method: POST
+    uri: https://api.anthropic.com/v1/messages
+  response:
+    body:
+      string: 'event: message_start
+
+        data: {"type":"message_start","message":{"model":"claude-opus-4-6","id":"msg_01RtVNwYH2vM9SnBWNptSdTu","type":"message","role":"assistant","content":[],"stop_reason":null,"stop_sequence":null,"usage":{"input_tokens":17,"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"cache_creation":{"ephemeral_5m_input_tokens":0,"ephemeral_1h_input_tokens":0},"output_tokens":1,"service_tier":"standard","inference_geo":"global"}}
+        }
+
+
+        event: content_block_start
+
+        data: {"type":"content_block_start","index":0,"content_block":{"type":"text","text":""}               }
+
+
+        event: ping
+
+        data: {"type": "ping"}
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"1"}       }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":".
+        **"}               }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"Captain"}             }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"
+        Sc"}   }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"oop"}               }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"**"}       }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"\n2.
+        **Gul"}               }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"let"}
+        }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"**"}     }
+
+
+        event: content_block_stop
+
+        data: {"type":"content_block_stop","index":0 }
+
+
+        event: message_delta
+
+        data: {"type":"message_delta","delta":{"stop_reason":"end_turn","stop_sequence":null},"usage":{"input_tokens":17,"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"output_tokens":20}}
+
+
+        event: message_stop
+
+        data: {"type":"message_stop"       }
+
+
+        '
+    headers:
+      CF-RAY:
+      - 9cf7b1075a7ce1f7-ORD
+      Cache-Control:
+      - no-cache
+      Connection:
+      - keep-alive
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - text/event-stream; charset=utf-8
+      Date:
+      - Tue, 17 Feb 2026 19:29:08 GMT
+      Server:
+      - cloudflare
+      Transfer-Encoding:
+      - chunked
+      X-Robots-Tag:
+      - none
+      anthropic-organization-id:
+      - b320df16-c763-4455-b901-3f7d54e9a012
+      anthropic-ratelimit-input-tokens-limit:
+      - '2000000'
+      anthropic-ratelimit-input-tokens-remaining:
+      - '2000000'
+      anthropic-ratelimit-input-tokens-reset:
+      - '2026-02-17T19:29:06Z'
+      anthropic-ratelimit-output-tokens-limit:
+      - '400000'
+      anthropic-ratelimit-output-tokens-remaining:
+      - '400000'
+      anthropic-ratelimit-output-tokens-reset:
+      - '2026-02-17T19:29:06Z'
+      anthropic-ratelimit-requests-limit:
+      - '4000'
+      anthropic-ratelimit-requests-remaining:
+      - '3999'
+      anthropic-ratelimit-requests-reset:
+      - '2026-02-17T19:29:06Z'
+      anthropic-ratelimit-tokens-limit:
+      - '2400000'
+      anthropic-ratelimit-tokens-remaining:
+      - '2400000'
+      anthropic-ratelimit-tokens-reset:
+      - '2026-02-17T19:29:06Z'
+      cf-cache-status:
+      - DYNAMIC
+      request-id:
+      - req_011CYECDz3EQCKTYoHsYLdYA
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains; preload
+      x-envoy-upstream-service-time:
+      - '3408'
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/cassettes/test_anthropic/test_opus_46_schema.yaml
+++ b/tests/cassettes/test_anthropic/test_opus_46_schema.yaml
@@ -1,0 +1,423 @@
+interactions:
+- request:
+    body: '{"max_tokens":8192,"messages":[{"role":"user","content":[{"type":"text","text":"Invent
+      a good dog"}]}],"model":"claude-opus-4-6","output_config":{"format":{"type":"json_schema","schema":{"type":"object","title":"Dog","properties":{"name":{"type":"string","title":"Name"},"age":{"type":"integer","title":"Age"},"bio":{"type":"string","title":"Bio"}},"additionalProperties":false,"required":["name","age","bio"]}}},"temperature":1.0,"stream":true}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '445'
+      Content-Type:
+      - application/json
+      Host:
+      - api.anthropic.com
+      User-Agent:
+      - Anthropic/Python 0.79.0
+      X-Stainless-Arch:
+      - x64
+      X-Stainless-Async:
+      - 'false'
+      X-Stainless-Helper-Method:
+      - stream
+      X-Stainless-Lang:
+      - python
+      X-Stainless-OS:
+      - Linux
+      X-Stainless-Package-Version:
+      - 0.79.0
+      X-Stainless-Runtime:
+      - CPython
+      X-Stainless-Runtime-Version:
+      - 3.11.14
+      X-Stainless-Stream-Helper:
+      - messages
+      anthropic-version:
+      - '2023-06-01'
+      x-stainless-read-timeout:
+      - '600'
+      x-stainless-retry-count:
+      - '0'
+      x-stainless-timeout:
+      - NOT_GIVEN
+    method: POST
+    uri: https://api.anthropic.com/v1/messages
+  response:
+    body:
+      string: 'event: message_start
+
+        data: {"type":"message_start","message":{"model":"claude-opus-4-6","id":"msg_01RiZf5w2bQ3qPCnAETmsdqt","type":"message","role":"assistant","content":[],"stop_reason":null,"stop_sequence":null,"usage":{"input_tokens":231,"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"cache_creation":{"ephemeral_5m_input_tokens":0,"ephemeral_1h_input_tokens":0},"output_tokens":1,"service_tier":"standard","inference_geo":"global"}}    }
+
+
+        event: content_block_start
+
+        data: {"type":"content_block_start","index":0,"content_block":{"type":"text","text":""}         }
+
+
+        event: ping
+
+        data: {"type": "ping"}
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"{\""}       }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"name\":\""}  }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"B"}     }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"iscuit\",\"age\":4"}     }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":",\"bio\":\"Biscuit
+        is"}     }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"
+        a golden"}              }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"
+        retriever with"}           }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"
+        a"}               }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"
+        heart"}    }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"
+        of pure"}          }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"
+        sunshine"}    }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"."}    }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"
+        He loves fet"} }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"ching
+        tennis"}        }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"
+        balls,"}             }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"
+        cu"}            }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"ddling
+        on"}  }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"
+        the couch during"} }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"
+        thunder"}       }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"storms,
+        and greeting"}    }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"
+        every"}     }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"
+        single"}}
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"
+        person he meets with an"}              }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"
+        enthusiastic tail"}          }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"
+        wag. He knows"}             }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"
+        twelve"}            }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"
+        tricks"}           }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":","}      }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"
+        but"}          }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"
+        his"}     }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"
+        favorite is "}           }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"''shake"}              }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":",''"}           }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"
+        because"}        }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"
+        it"}            }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"
+        means"} }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"
+        he gets to hold"}              }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"
+        your"}             }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"
+        hand."}         }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"
+        Biscuit volunteers"}        }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"
+        as"}      }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"
+        a therapy dog at the local children"}        }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"''s
+        hospital every"} }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"
+        Saturday"}    }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"
+        and"} }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"
+        has never"}     }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"
+        met"}        }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"
+        a stranger in"}             }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"
+        his life.\"}"}    }
+
+
+        event: content_block_stop
+
+        data: {"type":"content_block_stop","index":0         }
+
+
+        event: message_delta
+
+        data: {"type":"message_delta","delta":{"stop_reason":"end_turn","stop_sequence":null},"usage":{"input_tokens":231,"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"output_tokens":118}            }
+
+
+        event: message_stop
+
+        data: {"type":"message_stop"         }
+
+
+        '
+    headers:
+      CF-RAY:
+      - 9cf7b3a01d88f608-ORD
+      Cache-Control:
+      - no-cache
+      Connection:
+      - keep-alive
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - text/event-stream; charset=utf-8
+      Date:
+      - Tue, 17 Feb 2026 19:30:53 GMT
+      Server:
+      - cloudflare
+      Transfer-Encoding:
+      - chunked
+      X-Robots-Tag:
+      - none
+      anthropic-organization-id:
+      - b320df16-c763-4455-b901-3f7d54e9a012
+      anthropic-ratelimit-input-tokens-limit:
+      - '2000000'
+      anthropic-ratelimit-input-tokens-remaining:
+      - '2000000'
+      anthropic-ratelimit-input-tokens-reset:
+      - '2026-02-17T19:30:51Z'
+      anthropic-ratelimit-output-tokens-limit:
+      - '400000'
+      anthropic-ratelimit-output-tokens-remaining:
+      - '400000'
+      anthropic-ratelimit-output-tokens-reset:
+      - '2026-02-17T19:30:51Z'
+      anthropic-ratelimit-requests-limit:
+      - '4000'
+      anthropic-ratelimit-requests-remaining:
+      - '3999'
+      anthropic-ratelimit-requests-reset:
+      - '2026-02-17T19:30:51Z'
+      anthropic-ratelimit-tokens-limit:
+      - '2400000'
+      anthropic-ratelimit-tokens-remaining:
+      - '2400000'
+      anthropic-ratelimit-tokens-reset:
+      - '2026-02-17T19:30:51Z'
+      cf-cache-status:
+      - DYNAMIC
+      request-id:
+      - req_011CYECMj6nCZcGceaB8RRyq
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains; preload
+      x-envoy-upstream-service-time:
+      - '2096'
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/cassettes/test_anthropic/test_prompt.yaml
+++ b/tests/cassettes/test_anthropic/test_prompt.yaml
@@ -18,17 +18,19 @@ interactions:
       host:
       - api.anthropic.com
       user-agent:
-      - Anthropic/Python 0.73.0
+      - Anthropic/Python 0.80.0
       x-stainless-arch:
       - arm64
       x-stainless-async:
       - 'false'
+      x-stainless-helper-method:
+      - stream
       x-stainless-lang:
       - python
       x-stainless-os:
       - MacOS
       x-stainless-package-version:
-      - 0.73.0
+      - 0.80.0
       x-stainless-read-timeout:
       - '600'
       x-stainless-retry-count:
@@ -47,28 +49,28 @@ interactions:
     body:
       string: 'event: message_start
 
-        data: {"type":"message_start","message":{"model":"claude-sonnet-4-5-20250929","id":"msg_014Z12bJxZvKUjLkhBzUz358","type":"message","role":"assistant","content":[],"stop_reason":null,"stop_sequence":null,"usage":{"input_tokens":17,"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"cache_creation":{"ephemeral_5m_input_tokens":0,"ephemeral_1h_input_tokens":0},"output_tokens":1,"service_tier":"standard"}}  }
+        data: {"type":"message_start","message":{"model":"claude-sonnet-4-5-20250929","id":"msg_017A4s3HAsrqf5d2WvBmrpLr","type":"message","role":"assistant","content":[],"stop_reason":null,"stop_sequence":null,"usage":{"input_tokens":17,"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"cache_creation":{"ephemeral_5m_input_tokens":0,"ephemeral_1h_input_tokens":0},"output_tokens":1,"service_tier":"standard","inference_geo":"not_available"}}               }
 
 
         event: content_block_start
 
-        data: {"type":"content_block_start","index":0,"content_block":{"type":"text","text":""}}
-
-
-        event: content_block_delta
-
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"-"}       }
-
-
-        event: content_block_delta
-
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"
-        Captain"}   }
+        data: {"type":"content_block_start","index":0,"content_block":{"type":"text","text":""}   }
 
 
         event: ping
 
         data: {"type": "ping"}
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"-"}}
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"
+        Captain"}          }
 
 
         event: content_block_delta
@@ -79,7 +81,7 @@ interactions:
 
         event: content_block_delta
 
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"oop"}         }
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"oop"}     }
 
 
         event: content_block_stop
@@ -89,26 +91,28 @@ interactions:
 
         event: message_delta
 
-        data: {"type":"message_delta","delta":{"stop_reason":"end_turn","stop_sequence":null},"usage":{"input_tokens":17,"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"output_tokens":10}}
+        data: {"type":"message_delta","delta":{"stop_reason":"end_turn","stop_sequence":null},"usage":{"input_tokens":17,"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"output_tokens":10}        }
 
 
         event: message_stop
 
-        data: {"type":"message_stop"               }
+        data: {"type":"message_stop" }
 
 
         '
     headers:
       CF-RAY:
-      - 99eaca00b8067e2d-SJC
+      - 9cf926b51f134973-SJC
       Cache-Control:
       - no-cache
       Connection:
       - keep-alive
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - text/event-stream; charset=utf-8
       Date:
-      - Sat, 15 Nov 2025 00:56:31 GMT
+      - Tue, 17 Feb 2026 23:44:12 GMT
       Server:
       - cloudflare
       Transfer-Encoding:
@@ -122,29 +126,33 @@ interactions:
       anthropic-ratelimit-input-tokens-remaining:
       - '2000000'
       anthropic-ratelimit-input-tokens-reset:
-      - '2025-11-15T00:56:29Z'
+      - '2026-02-17T23:44:11Z'
       anthropic-ratelimit-output-tokens-limit:
       - '400000'
       anthropic-ratelimit-output-tokens-remaining:
       - '400000'
       anthropic-ratelimit-output-tokens-reset:
-      - '2025-11-15T00:56:29Z'
+      - '2026-02-17T23:44:11Z'
+      anthropic-ratelimit-requests-limit:
+      - '20000'
+      anthropic-ratelimit-requests-remaining:
+      - '19999'
+      anthropic-ratelimit-requests-reset:
+      - '2026-02-17T23:44:11Z'
       anthropic-ratelimit-tokens-limit:
       - '2400000'
       anthropic-ratelimit-tokens-remaining:
       - '2400000'
       anthropic-ratelimit-tokens-reset:
-      - '2025-11-15T00:56:29Z'
+      - '2026-02-17T23:44:11Z'
       cf-cache-status:
       - DYNAMIC
       request-id:
-      - req_011CV8mLyP9MnkAHjmZDx7Wv
-      retry-after:
-      - '33'
+      - req_011CYEXg9iLMo4YhB4XfkXBw
       strict-transport-security:
       - max-age=31536000; includeSubDomains; preload
       x-envoy-upstream-service-time:
-      - '1670'
+      - '943'
     status:
       code: 200
       message: OK

--- a/tests/cassettes/test_anthropic/test_schema_prompt_async.yaml
+++ b/tests/cassettes/test_anthropic/test_schema_prompt_async.yaml
@@ -1,7 +1,7 @@
 interactions:
 - request:
     body: '{"max_tokens":8192,"messages":[{"role":"user","content":[{"type":"text","text":"Invent
-      a terrific dog"}]}],"model":"claude-sonnet-4-5","output_format":{"schema":{"type":"object","title":"Dog","properties":{"name":{"type":"string","title":"Name"},"age":{"type":"integer","title":"Age"},"bio":{"type":"string","title":"Bio"}},"additionalProperties":false,"required":["name","age","bio"]},"type":"json_schema"},"temperature":1.0,"stream":true}'
+      a terrific dog"}]}],"model":"claude-sonnet-4-5","output_config":{"format":{"schema":{"type":"object","title":"Dog","properties":{"name":{"type":"string","title":"Name"},"age":{"type":"integer","title":"Age"},"bio":{"type":"string","title":"Bio"}},"additionalProperties":false,"required":["name","age","bio"]},"type":"json_schema"}},"temperature":1.0,"stream":true}'
     headers:
       accept:
       - application/json
@@ -14,23 +14,25 @@ interactions:
       connection:
       - keep-alive
       content-length:
-      - '440'
+      - '451'
       content-type:
       - application/json
       host:
       - api.anthropic.com
       user-agent:
-      - AsyncAnthropic/Python 0.73.0
+      - AsyncAnthropic/Python 0.80.0
       x-stainless-arch:
       - arm64
       x-stainless-async:
       - async:asyncio
+      x-stainless-helper-method:
+      - stream
       x-stainless-lang:
       - python
       x-stainless-os:
       - MacOS
       x-stainless-package-version:
-      - 0.73.0
+      - 0.80.0
       x-stainless-read-timeout:
       - '600'
       x-stainless-retry-count:
@@ -44,355 +46,89 @@ interactions:
       x-stainless-timeout:
       - NOT_GIVEN
     method: POST
-    uri: https://api.anthropic.com/v1/messages
+    uri: https://api.anthropic.com/v1/messages?beta=true
   response:
     body:
-      string: 'event: message_start
-
-        data: {"type":"message_start","message":{"model":"claude-sonnet-4-5-20250929","id":"msg_01Y7Y5yFVZLtqGuTkCsdTPka","type":"message","role":"assistant","content":[],"stop_reason":null,"stop_sequence":null,"usage":{"input_tokens":231,"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"cache_creation":{"ephemeral_5m_input_tokens":0,"ephemeral_1h_input_tokens":0},"output_tokens":1,"service_tier":"standard"}}         }
-
-
-        event: content_block_start
-
-        data: {"type":"content_block_start","index":0,"content_block":{"type":"text","text":""}   }
-
-
-        event: content_block_delta
-
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"{\""}             }
-
-
-        event: content_block_delta
-
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"name\":\""}             }
-
-
-        event: ping
-
-        data: {"type": "ping"}
-
-
-        event: content_block_delta
-
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"B"}          }
-
-
-        event: content_block_delta
-
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"isc"}      }
-
-
-        event: content_block_delta
-
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"uit\",\"age\":3,\"bio\":\""}
-        }
-
-
-        event: content_block_delta
-
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"B"}}
-
-
-        event: content_block_delta
-
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"iscuit
-        is a golden"}          }
-
-
-        event: content_block_delta
-
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"
-        retriever with"}           }
-
-
-        event: content_block_delta
-
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"
-        a heart of"}               }
-
-
-        event: content_block_delta
-
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"
-        pure"}          }
-
-
-        event: content_block_delta
-
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"
-        sunshine"}              }
-
-
-        event: content_block_delta
-
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":".
-        This"}   }
-
-
-        event: content_block_delta
-
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"
-        enthusi"}  }
-
-
-        event: content_block_delta
-
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"astic
-        pup has"}            }
-
-
-        event: content_block_delta
-
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"
-        mas"}       }
-
-
-        event: content_block_delta
-
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"tered
-        over"}  }
-
-
-        event: content_block_delta
-
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"
-        50"}               }
-
-
-        event: content_block_delta
-
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"
-        tricks"}   }
-
-
-        event: content_block_delta
-
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":","}   }
-
-
-        event: content_block_delta
-
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"
-        volunteers"}     }
-
-
-        event: content_block_delta
-
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"
-        at the"}     }
-
-
-        event: content_block_delta
-
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"
-        local children"}        }
-
-
-        event: content_block_delta
-
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"''s
-        hospital bringing"}              }
-
-
-        event: content_block_delta
-
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"
-        sm"}         }
-
-
-        event: content_block_delta
-
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"iles
-        to young"}          }
-
-
-        event: content_block_delta
-
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"
-        patients"}    }
-
-
-        event: content_block_delta
-
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":",
-        and has an"}          }
-
-
-        event: content_block_delta
-
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"
-        uncanny ability to sense"}        }
-
-
-        event: content_block_delta
-
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"
-        when someone needs comfort"}     }
-
-
-        event: content_block_delta
-
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":".
-        With"}             }
-
-
-        event: content_block_delta
-
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"
-        her"}  }
-
-
-        event: content_block_delta
-
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"
-        flowing"}          }
-
-
-        event: content_block_delta
-
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"
-        golden coat,"} }
-
-
-        event: content_block_delta
-
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"
-        perpet"}      }
-
-
-        event: content_block_delta
-
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"ually
-        wagging tail, and gentle brown"}        }
-
-
-        event: content_block_delta
-
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"
-        eyes, Biscuit emb"}      }
-
-
-        event: content_block_delta
-
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"odies
-        loyalty"}             }
-
-
-        event: content_block_delta
-
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"
-        an"}}
-
-
-        event: content_block_delta
-
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"d
-        joy"}               }
-
-
-        event: content_block_delta
-
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":".
-        She loves"}             }
-
-
-        event: content_block_delta
-
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"
-        swimming"}    }
-
-
-        event: content_block_delta
-
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"
-        in"}         }
-
-
-        event: content_block_delta
-
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"
-        lakes"}    }
-
-
-        event: content_block_delta
-
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":",
-        playing fetch until"}            }
-
-
-        event: content_block_delta
-
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"
-        sunset"}              }
-
-
-        event: content_block_delta
-
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":",
-        and cur"}          }
-
-
-        event: content_block_delta
-
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"ling
-        up for"}          }
-
-
-        event: content_block_delta
-
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"
-        story"}      }
-
-
-        event: content_block_delta
-
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"
-        time with"}              }
-
-
-        event: content_block_delta
-
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"
-        her family"}       }
-
-
-        event: content_block_delta
-
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"."}          }
-
-
-        event: content_block_delta
-
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"\"}"}               }
-
-
-        event: content_block_stop
-
-        data: {"type":"content_block_stop","index":0               }
-
-
-        event: message_delta
-
-        data: {"type":"message_delta","delta":{"stop_reason":"end_turn","stop_sequence":null},"usage":{"input_tokens":231,"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"output_tokens":124}          }
-
-
-        event: message_stop
-
-        data: {"type":"message_stop"               }
-
-
-        '
+      string: "event: message_start\ndata: {\"type\":\"message_start\",\"message\":{\"model\":\"claude-sonnet-4-5-20250929\",\"id\":\"msg_01EYgYrYGjMEwSoVocYfw61F\",\"type\":\"message\",\"role\":\"assistant\",\"content\":[],\"stop_reason\":null,\"stop_sequence\":null,\"usage\":{\"input_tokens\":231,\"cache_creation_input_tokens\":0,\"cache_read_input_tokens\":0,\"cache_creation\":{\"ephemeral_5m_input_tokens\":0,\"ephemeral_1h_input_tokens\":0},\"output_tokens\":1,\"service_tier\":\"standard\",\"inference_geo\":\"not_available\"}}
+        \  }\n\nevent: content_block_start\ndata: {\"type\":\"content_block_start\",\"index\":0,\"content_block\":{\"type\":\"text\",\"text\":\"\"}
+        \              }\n\nevent: ping\ndata: {\"type\": \"ping\"}\n\nevent: content_block_delta\ndata:
+        {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"text_delta\",\"text\":\"{\\\"\"}}\n\nevent:
+        content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"text_delta\",\"text\":\"name\\\":\\\"\"}
+        \        }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"text_delta\",\"text\":\"Neb\"}
+        \        }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"text_delta\",\"text\":\"ula\\\",\\\"age\\\":4\"}}\n\nevent:
+        content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"text_delta\",\"text\":\",\\\"bio\\\":\\\"Nebula
+        is a\"}          }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"text_delta\",\"text\":\"
+        spir\"}             }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"text_delta\",\"text\":\"ited
+        Australian\"}}\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"text_delta\",\"text\":\"
+        Shepherd mix\"}    }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"text_delta\",\"text\":\"
+        with\"}             }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"text_delta\",\"text\":\"
+        striking\"}            }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"text_delta\",\"text\":\"
+        blue-\"}               }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"text_delta\",\"text\":\"mer\"}
+        \   }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"text_delta\",\"text\":\"le
+        coat\"}             }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"text_delta\",\"text\":\"
+        and\"}    }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"text_delta\",\"text\":\"
+        one\"}}\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"text_delta\",\"text\":\"
+        bright\"}          }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"text_delta\",\"text\":\"
+        amber\"}      }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"text_delta\",\"text\":\"
+        eye,\"}   }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"text_delta\",\"text\":\"
+        one\"}             }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"text_delta\",\"text\":\"
+        pale\"}     }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"text_delta\",\"text\":\"
+        blue.\"}          }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"text_delta\",\"text\":\"
+        She's a certified\"}  }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"text_delta\",\"text\":\"
+        therapy dog who visits\"}             }\n\nevent: content_block_delta\ndata:
+        {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"text_delta\",\"text\":\"
+        children\"}     }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"text_delta\",\"text\":\"'s
+        hospitals weekly\"}         }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"text_delta\",\"text\":\",\"}
+        \    }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"text_delta\",\"text\":\"
+        has\"}               }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"text_delta\",\"text\":\"
+        an\"}          }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"text_delta\",\"text\":\"
+        unc\"}      }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"text_delta\",\"text\":\"anny
+        ability to sense when someone needs comfort\"}    }\n\nevent: content_block_delta\ndata:
+        {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"text_delta\",\"text\":\",
+        and loves solving\"}     }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"text_delta\",\"text\":\"
+        puzzle toys. Her\"}    }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"text_delta\",\"text\":\"
+        favorite activities\"}    }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"text_delta\",\"text\":\"
+        include ag\"}           }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"text_delta\",\"text\":\"ility
+        courses\"}     }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"text_delta\",\"text\":\",
+        swimming\"}            }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"text_delta\",\"text\":\"
+        in\"}               }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"text_delta\",\"text\":\"
+        lakes\"}      }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"text_delta\",\"text\":\",
+        and gentle\"}     }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"text_delta\",\"text\":\"
+        play\"}}\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"text_delta\",\"text\":\"
+        with her best\"}        }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"text_delta\",\"text\":\"
+        friend\u2014\"}  }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"text_delta\",\"text\":\"a
+        rescue\"}       }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"text_delta\",\"text\":\"
+        cat\"}        }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"text_delta\",\"text\":\"
+        named Co\"}               }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"text_delta\",\"text\":\"met.\"}
+        \    }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"text_delta\",\"text\":\"
+        Nebula once\"} }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"text_delta\",\"text\":\"
+        al\"}       }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"text_delta\",\"text\":\"erted
+        her family\"}              }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"text_delta\",\"text\":\"
+        to a gas\"} }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"text_delta\",\"text\":\"
+        leak,\"}        }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"text_delta\",\"text\":\"
+        saving\"}          }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"text_delta\",\"text\":\"
+        their\"}       }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"text_delta\",\"text\":\"
+        lives,\"}      }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"text_delta\",\"text\":\"
+        and she's currently\"}       }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"text_delta\",\"text\":\"
+        training\"}     }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"text_delta\",\"text\":\"
+        to be\"}         }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"text_delta\",\"text\":\"
+        a search\"}   }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"text_delta\",\"text\":\"
+        and rescue dog.\\\"}\"} }\n\nevent: content_block_stop\ndata: {\"type\":\"content_block_stop\",\"index\":0
+        \              }\n\nevent: message_delta\ndata: {\"type\":\"message_delta\",\"delta\":{\"stop_reason\":\"end_turn\",\"stop_sequence\":null},\"usage\":{\"input_tokens\":231,\"cache_creation_input_tokens\":0,\"cache_read_input_tokens\":0,\"output_tokens\":134}
+        \     }\n\nevent: message_stop\ndata: {\"type\":\"message_stop\"     }\n\n"
     headers:
       CF-RAY:
-      - 99eaf3ad0ac546f8-SJC
+      - 9cf926d94f72f46e-SJC
       Cache-Control:
       - no-cache
       Connection:
       - keep-alive
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - text/event-stream; charset=utf-8
       Date:
-      - Sat, 15 Nov 2025 01:24:58 GMT
+      - Tue, 17 Feb 2026 23:44:18 GMT
       Server:
       - cloudflare
       Transfer-Encoding:
@@ -406,29 +142,33 @@ interactions:
       anthropic-ratelimit-input-tokens-remaining:
       - '2000000'
       anthropic-ratelimit-input-tokens-reset:
-      - '2025-11-15T01:24:56Z'
+      - '2026-02-17T23:44:16Z'
       anthropic-ratelimit-output-tokens-limit:
       - '400000'
       anthropic-ratelimit-output-tokens-remaining:
       - '400000'
       anthropic-ratelimit-output-tokens-reset:
-      - '2025-11-15T01:24:56Z'
+      - '2026-02-17T23:44:16Z'
+      anthropic-ratelimit-requests-limit:
+      - '20000'
+      anthropic-ratelimit-requests-remaining:
+      - '19999'
+      anthropic-ratelimit-requests-reset:
+      - '2026-02-17T23:44:16Z'
       anthropic-ratelimit-tokens-limit:
       - '2400000'
       anthropic-ratelimit-tokens-remaining:
       - '2400000'
       anthropic-ratelimit-tokens-reset:
-      - '2025-11-15T01:24:56Z'
+      - '2026-02-17T23:44:16Z'
       cf-cache-status:
       - DYNAMIC
       request-id:
-      - req_011CV8oWoFD4NhGsP1FRpGLu
-      retry-after:
-      - '4'
+      - req_011CYEXgaQtBdwHLwUY4TfXv
       strict-transport-security:
       - max-age=31536000; includeSubDomains; preload
       x-envoy-upstream-service-time:
-      - '2099'
+      - '1338'
     status:
       code: 200
       message: OK

--- a/tests/cassettes/test_anthropic/test_sonnet_46_effort_without_thinking.yaml
+++ b/tests/cassettes/test_anthropic/test_sonnet_46_effort_without_thinking.yaml
@@ -1,0 +1,170 @@
+interactions:
+- request:
+    body: '{"max_tokens":8192,"messages":[{"role":"user","content":[{"type":"text","text":"Two
+      names for a pet pelican, be brief"}]}],"model":"claude-sonnet-4-6","output_config":{"effort":"low"},"temperature":1.0,"stream":true}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '216'
+      Content-Type:
+      - application/json
+      Host:
+      - api.anthropic.com
+      User-Agent:
+      - Anthropic/Python 0.79.0
+      X-Stainless-Arch:
+      - x64
+      X-Stainless-Async:
+      - 'false'
+      X-Stainless-Helper-Method:
+      - stream
+      X-Stainless-Lang:
+      - python
+      X-Stainless-OS:
+      - Linux
+      X-Stainless-Package-Version:
+      - 0.79.0
+      X-Stainless-Runtime:
+      - CPython
+      X-Stainless-Runtime-Version:
+      - 3.11.14
+      X-Stainless-Stream-Helper:
+      - messages
+      anthropic-version:
+      - '2023-06-01'
+      x-stainless-read-timeout:
+      - '600'
+      x-stainless-retry-count:
+      - '0'
+      x-stainless-timeout:
+      - NOT_GIVEN
+    method: POST
+    uri: https://api.anthropic.com/v1/messages
+  response:
+    body:
+      string: 'event: message_start
+
+        data: {"type":"message_start","message":{"model":"claude-sonnet-4-6","id":"msg_019Fb5TaLtGaCW5u5ApWj7YX","type":"message","role":"assistant","content":[],"stop_reason":null,"stop_sequence":null,"usage":{"input_tokens":17,"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"cache_creation":{"ephemeral_5m_input_tokens":0,"ephemeral_1h_input_tokens":0},"output_tokens":1,"service_tier":"standard","inference_geo":"global"}}     }
+
+
+        event: content_block_start
+
+        data: {"type":"content_block_start","index":0,"content_block":{"type":"text","text":""}     }
+
+
+        event: ping
+
+        data: {"type": "ping"}
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"**"}
+        }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"Pete"}              }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"**
+        and"}    }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"
+        **Sc"}   }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"oop"}              }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"**"}         }
+
+
+        event: content_block_stop
+
+        data: {"type":"content_block_stop","index":0}
+
+
+        event: message_delta
+
+        data: {"type":"message_delta","delta":{"stop_reason":"end_turn","stop_sequence":null},"usage":{"input_tokens":17,"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"output_tokens":12}  }
+
+
+        event: message_stop
+
+        data: {"type":"message_stop"       }
+
+
+        '
+    headers:
+      CF-RAY:
+      - 9cf7b2113cda60a5-ORD
+      Cache-Control:
+      - no-cache
+      Connection:
+      - keep-alive
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - text/event-stream; charset=utf-8
+      Date:
+      - Tue, 17 Feb 2026 19:29:48 GMT
+      Server:
+      - cloudflare
+      Transfer-Encoding:
+      - chunked
+      X-Robots-Tag:
+      - none
+      anthropic-organization-id:
+      - b320df16-c763-4455-b901-3f7d54e9a012
+      anthropic-ratelimit-input-tokens-limit:
+      - '2000000'
+      anthropic-ratelimit-input-tokens-remaining:
+      - '2000000'
+      anthropic-ratelimit-input-tokens-reset:
+      - '2026-02-17T19:29:47Z'
+      anthropic-ratelimit-output-tokens-limit:
+      - '400000'
+      anthropic-ratelimit-output-tokens-remaining:
+      - '400000'
+      anthropic-ratelimit-output-tokens-reset:
+      - '2026-02-17T19:29:47Z'
+      anthropic-ratelimit-requests-limit:
+      - '20000'
+      anthropic-ratelimit-requests-remaining:
+      - '19999'
+      anthropic-ratelimit-requests-reset:
+      - '2026-02-17T19:29:47Z'
+      anthropic-ratelimit-tokens-limit:
+      - '2400000'
+      anthropic-ratelimit-tokens-remaining:
+      - '2400000'
+      anthropic-ratelimit-tokens-reset:
+      - '2026-02-17T19:29:47Z'
+      cf-cache-status:
+      - DYNAMIC
+      request-id:
+      - req_011CYECH2GWBHCTuM9tfepPj
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains; preload
+      x-envoy-upstream-service-time:
+      - '378'
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/cassettes/test_anthropic/test_sonnet_46_prompt.yaml
+++ b/tests/cassettes/test_anthropic/test_sonnet_46_prompt.yaml
@@ -1,0 +1,165 @@
+interactions:
+- request:
+    body: '{"max_tokens":8192,"messages":[{"role":"user","content":[{"type":"text","text":"Two
+      names for a pet pelican, be brief"}]}],"model":"claude-sonnet-4-6","temperature":1.0,"stream":true}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '183'
+      Content-Type:
+      - application/json
+      Host:
+      - api.anthropic.com
+      User-Agent:
+      - Anthropic/Python 0.79.0
+      X-Stainless-Arch:
+      - x64
+      X-Stainless-Async:
+      - 'false'
+      X-Stainless-Helper-Method:
+      - stream
+      X-Stainless-Lang:
+      - python
+      X-Stainless-OS:
+      - Linux
+      X-Stainless-Package-Version:
+      - 0.79.0
+      X-Stainless-Runtime:
+      - CPython
+      X-Stainless-Runtime-Version:
+      - 3.11.14
+      X-Stainless-Stream-Helper:
+      - messages
+      anthropic-version:
+      - '2023-06-01'
+      x-stainless-read-timeout:
+      - '600'
+      x-stainless-retry-count:
+      - '0'
+      x-stainless-timeout:
+      - NOT_GIVEN
+    method: POST
+    uri: https://api.anthropic.com/v1/messages
+  response:
+    body:
+      string: 'event: message_start
+
+        data: {"type":"message_start","message":{"model":"claude-sonnet-4-6","id":"msg_01BCgDjb5HqsydH2BtaUkzpX","type":"message","role":"assistant","content":[],"stop_reason":null,"stop_sequence":null,"usage":{"input_tokens":17,"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"cache_creation":{"ephemeral_5m_input_tokens":0,"ephemeral_1h_input_tokens":0},"output_tokens":1,"service_tier":"standard","inference_geo":"global"}}           }
+
+
+        event: content_block_start
+
+        data: {"type":"content_block_start","index":0,"content_block":{"type":"text","text":""}            }
+
+
+        event: ping
+
+        data: {"type": "ping"}
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"**"}           }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"Pete"}    }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"**
+        or"}   }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"
+        **Sc"}               }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"oop**"}
+        }
+
+
+        event: content_block_stop
+
+        data: {"type":"content_block_stop","index":0      }
+
+
+        event: message_delta
+
+        data: {"type":"message_delta","delta":{"stop_reason":"end_turn","stop_sequence":null},"usage":{"input_tokens":17,"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"output_tokens":12}        }
+
+
+        event: message_stop
+
+        data: {"type":"message_stop"     }
+
+
+        '
+    headers:
+      CF-RAY:
+      - 9cf7b16a8d761269-ORD
+      Cache-Control:
+      - no-cache
+      Connection:
+      - keep-alive
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
+      Content-Type:
+      - text/event-stream; charset=utf-8
+      Date:
+      - Tue, 17 Feb 2026 19:29:21 GMT
+      Server:
+      - cloudflare
+      Transfer-Encoding:
+      - chunked
+      X-Robots-Tag:
+      - none
+      anthropic-organization-id:
+      - b320df16-c763-4455-b901-3f7d54e9a012
+      anthropic-ratelimit-input-tokens-limit:
+      - '2000000'
+      anthropic-ratelimit-input-tokens-remaining:
+      - '2000000'
+      anthropic-ratelimit-input-tokens-reset:
+      - '2026-02-17T19:29:21Z'
+      anthropic-ratelimit-output-tokens-limit:
+      - '400000'
+      anthropic-ratelimit-output-tokens-remaining:
+      - '400000'
+      anthropic-ratelimit-output-tokens-reset:
+      - '2026-02-17T19:29:21Z'
+      anthropic-ratelimit-requests-limit:
+      - '20000'
+      anthropic-ratelimit-requests-remaining:
+      - '19999'
+      anthropic-ratelimit-requests-reset:
+      - '2026-02-17T19:29:21Z'
+      anthropic-ratelimit-tokens-limit:
+      - '2400000'
+      anthropic-ratelimit-tokens-remaining:
+      - '2400000'
+      anthropic-ratelimit-tokens-reset:
+      - '2026-02-17T19:29:21Z'
+      cf-cache-status:
+      - DYNAMIC
+      request-id:
+      - req_011CYECF4FWS7MB96J7LdosM
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains; preload
+      x-envoy-upstream-service-time:
+      - '401'
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/cassettes/test_anthropic/test_thinking_prompt.yaml
+++ b/tests/cassettes/test_anthropic/test_thinking_prompt.yaml
@@ -1,7 +1,7 @@
 interactions:
 - request:
     body: '{"max_tokens":8192,"messages":[{"role":"user","content":[{"type":"text","text":"Two
-      names for a pet pelican, be brief"}]}],"model":"claude-3-7-sonnet-latest","temperature":1.0,"thinking":{"type":"enabled","budget_tokens":1024},"stream":true}'
+      names for a pet pelican, be brief"}]}],"model":"claude-sonnet-4-5","temperature":1.0,"thinking":{"type":"enabled","budget_tokens":1024},"stream":true}'
     headers:
       accept:
       - application/json
@@ -12,23 +12,25 @@ interactions:
       connection:
       - keep-alive
       content-length:
-      - '241'
+      - '234'
       content-type:
       - application/json
       host:
       - api.anthropic.com
       user-agent:
-      - Anthropic/Python 0.73.0
+      - Anthropic/Python 0.80.0
       x-stainless-arch:
       - arm64
       x-stainless-async:
       - 'false'
+      x-stainless-helper-method:
+      - stream
       x-stainless-lang:
       - python
       x-stainless-os:
       - MacOS
       x-stainless-package-version:
-      - 0.73.0
+      - 0.80.0
       x-stainless-read-timeout:
       - '600'
       x-stainless-retry-count:
@@ -47,24 +49,12 @@ interactions:
     body:
       string: 'event: message_start
 
-        data: {"type":"message_start","message":{"model":"claude-3-7-sonnet-20250219","id":"msg_016jUxJ1QxmZ2CJK7pQ89Jb1","type":"message","role":"assistant","content":[],"stop_reason":null,"stop_sequence":null,"usage":{"input_tokens":46,"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"cache_creation":{"ephemeral_5m_input_tokens":0,"ephemeral_1h_input_tokens":0},"output_tokens":5,"service_tier":"standard"}}               }
+        data: {"type":"message_start","message":{"model":"claude-sonnet-4-5-20250929","id":"msg_01RTjjePNDCQNgHXg3KeDPfv","type":"message","role":"assistant","content":[],"stop_reason":null,"stop_sequence":null,"usage":{"input_tokens":46,"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"cache_creation":{"ephemeral_5m_input_tokens":0,"ephemeral_1h_input_tokens":0},"output_tokens":3,"service_tier":"standard","inference_geo":"not_available"}}               }
 
 
         event: content_block_start
 
-        data: {"type":"content_block_start","index":0,"content_block":{"type":"thinking","thinking":"","signature":""}  }
-
-
-        event: content_block_delta
-
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"thinking_delta","thinking":"I
-        need to provide two"}           }
-
-
-        event: content_block_delta
-
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"thinking_delta","thinking":"
-        brief"}         }
+        data: {"type":"content_block_start","index":0,"content_block":{"type":"thinking","thinking":"","signature":""}      }
 
 
         event: ping
@@ -74,257 +64,235 @@ interactions:
 
         event: content_block_delta
 
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"thinking_delta","thinking":"
-        names for a pet pel"}       }
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"thinking_delta","thinking":"The
+        user wants"}             }
 
 
         event: content_block_delta
 
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"thinking_delta","thinking":"ican."}
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"thinking_delta","thinking":"
+        two names for a pet pelican,"}          }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"thinking_delta","thinking":"
+        and"}  }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"thinking_delta","thinking":"
+        wants"}       }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"thinking_delta","thinking":"
+        me"}    }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"thinking_delta","thinking":"
+        to be brief. I"}    }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"thinking_delta","thinking":"''ll"}        }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"thinking_delta","thinking":"
+        give"}            }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"thinking_delta","thinking":"
+        two"}         }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"thinking_delta","thinking":"
+        simple"}   }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"thinking_delta","thinking":",
+        fitting"}  }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"thinking_delta","thinking":"
+        names."}              }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"thinking_delta","thinking":"\n\nSome"}}
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"thinking_delta","thinking":"
+        options:\n-"}               }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"thinking_delta","thinking":"
+        Pete"}       }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"thinking_delta","thinking":"\n-
+        Percy"}            }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"thinking_delta","thinking":"\n-
+        Captain"}       }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"thinking_delta","thinking":"\n-
+        Sc"}    }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"thinking_delta","thinking":"oop"}      }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"thinking_delta","thinking":"\n-
+        Bill"}      }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"thinking_delta","thinking":"\n-
+        G"}  }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"thinking_delta","thinking":"ully"}
+        }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"thinking_delta","thinking":"\n\nI''ll"}
         }
 
 
         event: content_block_delta
 
         data: {"type":"content_block_delta","index":0,"delta":{"type":"thinking_delta","thinking":"
-        Pelicans are large"}   }
+        pick"}         }
 
 
         event: content_block_delta
 
         data: {"type":"content_block_delta","index":0,"delta":{"type":"thinking_delta","thinking":"
-        water"}             }
+        two good"}      }
 
 
         event: content_block_delta
 
         data: {"type":"content_block_delta","index":0,"delta":{"type":"thinking_delta","thinking":"
-        birds with distinctive"}    }
+        ones and"} }
 
 
         event: content_block_delta
 
         data: {"type":"content_block_delta","index":0,"delta":{"type":"thinking_delta","thinking":"
-        pou"}     }
-
-
-        event: content_block_delta
-
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"thinking_delta","thinking":"che"}               }
-
-
-        event: content_block_delta
-
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"thinking_delta","thinking":"d
-        bills,"}     }
+        keep it very"}     }
 
 
         event: content_block_delta
 
         data: {"type":"content_block_delta","index":0,"delta":{"type":"thinking_delta","thinking":"
-        so I coul"}   }
+        short"}              }
 
 
         event: content_block_delta
 
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"thinking_delta","thinking":"d
-        create"}            }
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"thinking_delta","thinking":"."}               }
 
 
         event: content_block_delta
 
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"thinking_delta","thinking":"
-        names that relate to:"}      }
-
-
-        event: content_block_delta
-
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"thinking_delta","thinking":"\n-
-        Their"}               }
-
-
-        event: content_block_delta
-
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"thinking_delta","thinking":"
-        appearance (bill"}          }
-
-
-        event: content_block_delta
-
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"thinking_delta","thinking":",
-        po"}  }
-
-
-        event: content_block_delta
-
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"thinking_delta","thinking":"uch)\n-
-        Water"}    }
-
-
-        event: content_block_delta
-
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"thinking_delta","thinking":"/"}     }
-
-
-        event: content_block_delta
-
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"thinking_delta","thinking":"ocean
-        themes\n- Their"}            }
-
-
-        event: content_block_delta
-
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"thinking_delta","thinking":"
-        fishing"}      }
-
-
-        event: content_block_delta
-
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"thinking_delta","thinking":"
-        abilities"}  }
-
-
-        event: content_block_delta
-
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"thinking_delta","thinking":"\n-
-        Classic"}             }
-
-
-        event: content_block_delta
-
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"thinking_delta","thinking":"
-        pet"}   }
-
-
-        event: content_block_delta
-
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"thinking_delta","thinking":"
-        names with"} }
-
-
-        event: content_block_delta
-
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"thinking_delta","thinking":"
-        a"}              }
-
-
-        event: content_block_delta
-
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"thinking_delta","thinking":"
-        twist"}       }
-
-
-        event: content_block_delta
-
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"thinking_delta","thinking":"\n\nI"}    }
-
-
-        event: content_block_delta
-
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"thinking_delta","thinking":"''ll
-        provide two short"}         }
-
-
-        event: content_block_delta
-
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"thinking_delta","thinking":",
-        creative"}      }
-
-
-        event: content_block_delta
-
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"thinking_delta","thinking":"
-        names without"}               }
-
-
-        event: content_block_delta
-
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"thinking_delta","thinking":"
-        additional"}       }
-
-
-        event: content_block_delta
-
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"thinking_delta","thinking":"
-        commentary"}  }
-
-
-        event: content_block_delta
-
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"thinking_delta","thinking":",
-        as the"}   }
-
-
-        event: content_block_delta
-
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"thinking_delta","thinking":"
-        request asks"}  }
-
-
-        event: content_block_delta
-
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"thinking_delta","thinking":"
-        me"}         }
-
-
-        event: content_block_delta
-
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"thinking_delta","thinking":"
-        to be brief."}     }
-
-
-        event: content_block_delta
-
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"signature_delta","signature":"ErUBCkYICRgCIkCUCsMUICiFm+sgvS255wUaTjAJEX2tc5h+Mir6Kq6OozIF+9a3ygFFnCLjPYf2Jl18eMVqkYVs0Vq9rRJpl6N/EgySPIWO4SVcxV0VqecaDM6REdwo/8lOJenaQCIwzQfkXeoR1nwYqsvrQsf4/NwhTuKfWDtM8a0XHfoH7EFwizaRuTrwV21Ny1nWKbu2Kh2qjLQOYn34/0pMKErgEexGTvXvn5PMMSAqOVqz8BgC"}        }
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"signature_delta","signature":"EvoCCkYICxgCKkCY593DZILKPT3+cK6Py3Hcu8WYGSW2vk6yge13JAuAYlQFzUC2c6UlsIWiBMvJjtDc6zfh73EOpWqxYB+pOh5zEgxoquY58aQkL5YJ9YUaDJpBRqMUVxU6SPYLRCIwcxSHXlhIWQw0QhiPV+lrMXgTdk4SuJnWVpHc+uTSxYmxetnHugsdCo6xWShRJaQLKuEBsfQzKHid0WmA8hdgz0mVpI+nAPvnhpHFIZbnGl2HQi7cc87o/HZzCod2tF8mEuqdyNtPHgx+H+Zyr/Pi0kmJF6hOoylmR5nGrXeqR1ttWFzzPF7XpmIr+vw3y/rNCDQVRWxmG/IDyHVLKXtALaFnDpNfvSGv6L3udrgkeWuV2VEzfGPclEIaailiMsxesYC/LJGUcPlqZ9kL18GQ16lr15u6kOUMlyYKA7AoeL6K7U3qCvpSdfGpMfgkasK5ugj0FL3UgFpUrrFbPlpLAdLsNeG2G+XBiOY0TtfokCiI1P7LGAE="}      }
 
 
         event: content_block_stop
 
-        data: {"type":"content_block_stop","index":0  }
+        data: {"type":"content_block_stop","index":0}
 
 
         event: content_block_start
 
-        data: {"type":"content_block_start","index":1,"content_block":{"type":"text","text":""}      }
+        data: {"type":"content_block_start","index":1,"content_block":{"type":"text","text":""}}
 
 
         event: content_block_delta
 
-        data: {"type":"content_block_delta","index":1,"delta":{"type":"text_delta","text":"Bill\nSc"}     }
+        data: {"type":"content_block_delta","index":1,"delta":{"type":"text_delta","text":"-"}       }
 
 
         event: content_block_delta
 
-        data: {"type":"content_block_delta","index":1,"delta":{"type":"text_delta","text":"oop"}               }
+        data: {"type":"content_block_delta","index":1,"delta":{"type":"text_delta","text":"
+        Captain"}}
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":1,"delta":{"type":"text_delta","text":"\n-
+        Scoop"}          }
 
 
         event: content_block_stop
 
-        data: {"type":"content_block_stop","index":1             }
+        data: {"type":"content_block_stop","index":1         }
 
 
         event: message_delta
 
-        data: {"type":"message_delta","delta":{"stop_reason":"end_turn","stop_sequence":null},"usage":{"input_tokens":46,"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"output_tokens":103}             }
+        data: {"type":"message_delta","delta":{"stop_reason":"end_turn","stop_sequence":null},"usage":{"input_tokens":46,"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"output_tokens":84}            }
 
 
         event: message_stop
 
-        data: {"type":"message_stop"   }
+        data: {"type":"message_stop"    }
 
 
         '
     headers:
       CF-RAY:
-      - 99eacabcfbe8250d-SJC
+      - 9cf926f8e85ced40-SJC
       Cache-Control:
       - no-cache
       Connection:
       - keep-alive
+      Content-Security-Policy:
+      - default-src 'none'; frame-ancestors 'none'
       Content-Type:
       - text/event-stream; charset=utf-8
       Date:
-      - Sat, 15 Nov 2025 00:57:00 GMT
+      - Tue, 17 Feb 2026 23:44:22 GMT
       Server:
       - cloudflare
       Transfer-Encoding:
@@ -334,39 +302,37 @@ interactions:
       anthropic-organization-id:
       - b320df16-c763-4455-b901-3f7d54e9a012
       anthropic-ratelimit-input-tokens-limit:
-      - '200000'
+      - '2000000'
       anthropic-ratelimit-input-tokens-remaining:
-      - '200000'
+      - '2000000'
       anthropic-ratelimit-input-tokens-reset:
-      - '2025-11-15T00:56:59Z'
+      - '2026-02-17T23:44:21Z'
       anthropic-ratelimit-output-tokens-limit:
-      - '80000'
+      - '400000'
       anthropic-ratelimit-output-tokens-remaining:
-      - '80000'
+      - '400000'
       anthropic-ratelimit-output-tokens-reset:
-      - '2025-11-15T00:56:59Z'
+      - '2026-02-17T23:44:21Z'
       anthropic-ratelimit-requests-limit:
-      - '4000'
+      - '20000'
       anthropic-ratelimit-requests-remaining:
-      - '3999'
+      - '19999'
       anthropic-ratelimit-requests-reset:
-      - '2025-11-15T00:56:59Z'
+      - '2026-02-17T23:44:21Z'
       anthropic-ratelimit-tokens-limit:
-      - '280000'
+      - '2400000'
       anthropic-ratelimit-tokens-remaining:
-      - '280000'
+      - '2400000'
       anthropic-ratelimit-tokens-reset:
-      - '2025-11-15T00:56:59Z'
+      - '2026-02-17T23:44:21Z'
       cf-cache-status:
       - DYNAMIC
       request-id:
-      - req_011CV8mPCBdgXRa4KmpEQQz7
-      retry-after:
-      - '1'
+      - req_011CYEXgx67iagYpjoqW9quB
       strict-transport-security:
       - max-age=31536000; includeSubDomains; preload
       x-envoy-upstream-service-time:
-      - '320'
+      - '889'
     status:
       code: 200
       message: OK

--- a/tests/test_anthropic.py
+++ b/tests/test_anthropic.py
@@ -281,3 +281,80 @@ def test_web_search():
     response_dict = dict(response.response_json)
     assert "content" in response_dict
     assert len(response_dict["content"]) > 0
+
+
+@pytest.mark.vcr
+def test_opus_46_prompt():
+    model = llm.get_model("claude-opus-4.6")
+    model.key = model.key or ANTHROPIC_API_KEY
+    response = model.prompt("Two names for a pet pelican, be brief")
+    text = response.text()
+    assert len(text) > 0
+    response_dict = dict(response.response_json)
+    assert response_dict["model"] == "claude-opus-4-6"
+    assert response.input_tokens > 0
+    assert response.output_tokens > 0
+
+
+@pytest.mark.vcr
+def test_sonnet_46_prompt():
+    model = llm.get_model("claude-sonnet-4.6")
+    model.key = model.key or ANTHROPIC_API_KEY
+    response = model.prompt("Two names for a pet pelican, be brief")
+    text = response.text()
+    assert len(text) > 0
+    response_dict = dict(response.response_json)
+    assert response_dict["model"] == "claude-sonnet-4-6"
+    assert response.input_tokens > 0
+    assert response.output_tokens > 0
+
+
+@pytest.mark.vcr
+def test_opus_46_adaptive_thinking():
+    model = llm.get_model("claude-opus-4.6")
+    model.key = model.key or ANTHROPIC_API_KEY
+    response = model.prompt(
+        "Two names for a pet pelican, be brief", thinking=True
+    )
+    text = response.text()
+    assert len(text) > 0
+    response_dict = dict(response.response_json)
+    # Should have thinking content in the response
+    content_types = [block["type"] for block in response_dict["content"]]
+    assert "thinking" in content_types
+    assert "text" in content_types
+
+
+@pytest.mark.vcr
+def test_sonnet_46_effort_without_thinking():
+    model = llm.get_model("claude-sonnet-4.6")
+    model.key = model.key or ANTHROPIC_API_KEY
+    response = model.prompt(
+        "Two names for a pet pelican, be brief", thinking_effort="low"
+    )
+    text = response.text()
+    assert len(text) > 0
+
+
+def test_46_prefill_rejected():
+    model = llm.get_model("claude-opus-4.6")
+    model.key = "test-key"
+    with pytest.raises(ValueError, match="Prefilling assistant messages is not supported"):
+        model.prompt("Hello", prefill="{").text()
+
+
+def test_46_max_effort_opus_only():
+    model = llm.get_model("claude-sonnet-4.6")
+    model.key = "test-key"
+    with pytest.raises(ValueError, match="thinking_effort='max' is only supported"):
+        model.prompt("Hello", thinking_effort="max").text()
+
+
+@pytest.mark.vcr
+def test_opus_46_schema():
+    model = llm.get_model("claude-opus-4.6")
+    response = model.prompt("Invent a good dog", schema=Dog, key=ANTHROPIC_API_KEY)
+    dog = json.loads(response.text())
+    assert "name" in dog
+    assert "age" in dog
+    assert "bio" in dog

--- a/tests/test_anthropic.py
+++ b/tests/test_anthropic.py
@@ -26,7 +26,8 @@ def test_prompt():
     response_dict = dict(response.response_json)
     response_dict.pop("id")  # differs between requests
     assert response_dict == {
-        "content": [{"citations": None, "text": "- Captain\n- Scoop", "type": "text"}],
+        "container": None,
+        "content": [{"citations": None, "parsed_output": None, "text": "- Captain\n- Scoop", "type": "text"}],
         "model": "claude-sonnet-4-5-20250929",
         "role": "assistant",
         "stop_reason": "end_turn",
@@ -49,7 +50,8 @@ async def test_async_prompt():
     response_dict = dict(response.response_json)
     response_dict.pop("id")  # differs between requests
     assert response_dict == {
-        "content": [{"citations": None, "text": "- Captain\n- Scoop", "type": "text"}],
+        "container": None,
+        "content": [{"citations": None, "parsed_output": None, "text": "- Captain\n- Scoop", "type": "text"}],
         "model": "claude-sonnet-4-5-20250929",
         "role": "assistant",
         "stop_reason": "end_turn",
@@ -60,7 +62,7 @@ async def test_async_prompt():
     assert response.output_tokens == 10
     assert response.token_details is None
     response2 = await conversation.prompt("in french")
-    assert await response2.text() == '- Capitaine\n- Bec (meaning "beak")'
+    assert await response2.text() == "- Capitaine\n- Bec (beak)"
 
 
 EXPECTED_IMAGE_TEXT = "Red square, green square."
@@ -78,7 +80,8 @@ def test_image_prompt():
     response_dict = response.response_json
     response_dict.pop("id")  # differs between requests
     assert response_dict == {
-        "content": [{"citations": None, "text": EXPECTED_IMAGE_TEXT, "type": "text"}],
+        "container": None,
+        "content": [{"citations": None, "parsed_output": None, "text": EXPECTED_IMAGE_TEXT, "type": "text"}],
         "model": "claude-sonnet-4-5-20250929",
         "role": "assistant",
         "stop_reason": "end_turn",
@@ -175,17 +178,18 @@ async def test_schema_prompt_async():
     dog_json = await response.text()
     dog = json.loads(dog_json)
     assert dog == {
-        "age": 3,
+        "age": 4,
         "bio": (
-            "Biscuit is a golden retriever with a heart of pure sunshine. This "
-            "enthusiastic pup has mastered over 50 tricks, volunteers at the local "
-            "children's hospital bringing smiles to young patients, and has an uncanny "
-            "ability to sense when someone needs comfort. With her flowing golden "
-            "coat, perpetually wagging tail, and gentle brown eyes, Biscuit embodies "
-            "loyalty and joy. She loves swimming in lakes, playing fetch until sunset, "
-            "and curling up for story time with her family."
+            "Nebula is a spirited Australian Shepherd mix with striking blue-merle "
+            "coat and one bright amber eye, one pale blue. She's a certified therapy "
+            "dog who visits children's hospitals weekly, has an uncanny ability to "
+            "sense when someone needs comfort, and loves solving puzzle toys. Her "
+            "favorite activities include agility courses, swimming in lakes, and "
+            "gentle play with her best friend\u2014a rescue cat named Comet. Nebula "
+            "once alerted her family to a gas leak, saving their lives, and she's "
+            "currently training to be a search and rescue dog."
         ),
-        "name": "Biscuit",
+        "name": "Nebula",
     }
 
 
@@ -214,19 +218,20 @@ def test_thinking_prompt():
     response = conversation.prompt(
         "Two names for a pet pelican, be brief", thinking=True, key=ANTHROPIC_API_KEY
     )
-    assert response.text() == "Bill\nScoop"
+    assert response.text() == "- Captain\n- Scoop"
     response_dict = dict(response.response_json)
     response_dict.pop("id")  # differs between requests
     assert response_dict == {
+        "container": None,
         "content": [
             {
-                "signature": "ErUBCkYICRgCIkCUCsMUICiFm+sgvS255wUaTjAJEX2tc5h+Mir6Kq6OozIF+9a3ygFFnCLjPYf2Jl18eMVqkYVs0Vq9rRJpl6N/EgySPIWO4SVcxV0VqecaDM6REdwo/8lOJenaQCIwzQfkXeoR1nwYqsvrQsf4/NwhTuKfWDtM8a0XHfoH7EFwizaRuTrwV21Ny1nWKbu2Kh2qjLQOYn34/0pMKErgEexGTvXvn5PMMSAqOVqz8BgC",
-                "thinking": "I need to provide two brief names for a pet pelican. Pelicans are large water birds with distinctive pouched bills, so I could create names that relate to:\n- Their appearance (bill, pouch)\n- Water/ocean themes\n- Their fishing abilities\n- Classic pet names with a twist\n\nI'll provide two short, creative names without additional commentary, as the request asks me to be brief.",
+                "signature": "EvoCCkYICxgCKkCY593DZILKPT3+cK6Py3Hcu8WYGSW2vk6yge13JAuAYlQFzUC2c6UlsIWiBMvJjtDc6zfh73EOpWqxYB+pOh5zEgxoquY58aQkL5YJ9YUaDJpBRqMUVxU6SPYLRCIwcxSHXlhIWQw0QhiPV+lrMXgTdk4SuJnWVpHc+uTSxYmxetnHugsdCo6xWShRJaQLKuEBsfQzKHid0WmA8hdgz0mVpI+nAPvnhpHFIZbnGl2HQi7cc87o/HZzCod2tF8mEuqdyNtPHgx+H+Zyr/Pi0kmJF6hOoylmR5nGrXeqR1ttWFzzPF7XpmIr+vw3y/rNCDQVRWxmG/IDyHVLKXtALaFnDpNfvSGv6L3udrgkeWuV2VEzfGPclEIaailiMsxesYC/LJGUcPlqZ9kL18GQ16lr15u6kOUMlyYKA7AoeL6K7U3qCvpSdfGpMfgkasK5ugj0FL3UgFpUrrFbPlpLAdLsNeG2G+XBiOY0TtfokCiI1P7LGAE=",
+                "thinking": "The user wants two names for a pet pelican, and wants me to be brief. I'll give two simple, fitting names.\n\nSome options:\n- Pete\n- Percy\n- Captain\n- Scoop\n- Bill\n- Gully\n\nI'll pick two good ones and keep it very short.",
                 "type": "thinking",
             },
-            {"citations": None, "text": "Bill\nScoop", "type": "text"},
+            {"citations": None, "parsed_output": None, "text": "- Captain\n- Scoop", "type": "text"},
         ],
-        "model": "claude-3-7-sonnet-20250219",
+        "model": "claude-sonnet-4-5-20250929",
         "role": "assistant",
         "stop_reason": "end_turn",
         "stop_sequence": None,
@@ -234,7 +239,7 @@ def test_thinking_prompt():
     }
 
     assert response.input_tokens == 46
-    assert response.output_tokens == 103
+    assert response.output_tokens == 84
     assert response.token_details is None
 
 


### PR DESCRIPTION
> Clone https://gist.github.com/3cb9bb0e3f7c3711f24731ec2dba76db.git to /tmp and read it
>
> Also clone simonw/llm to /tmp/llm for reference
>
> Your job is to integrate Opus 4.6 and Sonnet 4.6 into this library, but first we need to determine what missing features we need to add to support things in this new model
>
> Base URL for the docs is https://platform.claude.com/ - use that to fetch extra information that you need
>
> Run ‘uv llm models’ to list existing models and try a prompt with ‘uv llm -m claude-haiku-4.5 hi’

## Summary
This PR adds support for the new Claude 4.6 model family (Opus and Sonnet) with enhanced capabilities including adaptive thinking, structured outputs, and web search support.

## Key Changes

- **New Models**: Added `claude-opus-4-6` and `claude-sonnet-4-6` model registrations with full feature support
- **Adaptive Thinking**: Introduced `supports_adaptive_thinking` flag to distinguish between pre-GA thinking (Opus 4.5) and GA adaptive thinking (4.6 models)
- **Thinking Effort**: Added `MAX` effort level to `ThinkingEffort` enum for Opus 4.6 exclusive use
- **Structured Outputs**: Enabled `use_structured_outputs=True` for both new models
- **Web Search**: Added support for web search on the new models
- **Prefill Validation**: Added check to reject prefill requests on 4.6 models (not supported with adaptive thinking)
- **Thinking Logic Refactor**: Updated thinking activation logic to handle both manual thinking mode (with budget) and adaptive thinking mode separately
- **Effort Validation**: Added validation to ensure `thinking_effort='max'` is only used with Opus 4.6

## Implementation Details

- The adaptive thinking implementation uses `{"type": "adaptive"}` format instead of the manual `{"type": "enabled", "budget_tokens": N}` format used by Opus 4.5
- Effort levels on 4.6 models are passed via `output_config` rather than implying thinking activation
- Web search support extended to include the new 4.6 models in error messages
- Comprehensive test coverage added with VCR cassettes for prompt, adaptive thinking, effort, and schema validation scenarios

https://claude.ai/code/session_01HAzs41MeCobQVoagbXxyL2