### PR TITLE
Add base_url option to ClaudeOptions

### DIFF
--- a/llm_anthropic.py
+++ b/llm_anthropic.py
@@ -383,6 +383,11 @@ class ClaudeOptions(llm.Options):
         default=None,
     )
 
+    base_url: Optional[str] = Field(
+        description="Custom base URL for the Anthropic API, e.g. for proxies or self-hosted endpoints",
+        default=None,
+    )
+
     @field_validator("stop_sequences")
     def validate_stop_sequences(cls, stop_sequences):
         error_msg = "stop_sequences must be a list of strings or a single string"
@@ -974,7 +979,8 @@ class _Shared:
 
 class ClaudeMessages(_Shared, llm.KeyModel):
     def execute(self, prompt, stream, response, conversation, key):
-        client = Anthropic(api_key=self.get_key(key), base_url=self.base_url)
+        base_url = prompt.options.base_url or self.base_url
+        client = Anthropic(api_key=self.get_key(key), base_url=base_url)
         kwargs = self.build_kwargs(prompt, conversation)
         prefill_text = self.prefill_text(prompt)
         if "betas" in kwargs:
@@ -1121,7 +1127,8 @@ class ClaudeMessages(_Shared, llm.KeyModel):
 
 class AsyncClaudeMessages(_Shared, llm.AsyncKeyModel):
     async def execute(self, prompt, stream, response, conversation, key):
-        client = AsyncAnthropic(api_key=self.get_key(key), base_url=self.base_url)
+        base_url = prompt.options.base_url or self.base_url
+        client = AsyncAnthropic(api_key=self.get_key(key), base_url=base_url)
         kwargs = self.build_kwargs(prompt, conversation)
         if "betas" in kwargs:
             messages_client = client.beta.messages

--- a/tests/test_anthropic.py
+++ b/tests/test_anthropic.py
@@ -4,6 +4,7 @@ import os
 import pytest
 from inline_snapshot import snapshot
 from pydantic import BaseModel
+from unittest.mock import patch, MagicMock
 
 TINY_PNG = (
     b"\x89PNG\r\n\x1a\n\x00\x00\x00\rIHDR\x00\x00\x00\xa6\x00\x00\x01\x1a"
@@ -793,3 +794,67 @@ def test_extract_system_prefers_prompt_system_over_messages():
     model = llm.get_model("claude-sonnet-4.5")
     p = llm.Prompt(None, model=model, system="legacy sys", messages=[user("hi")])
     assert model._extract_system(p) == "legacy sys"
+
+
+def test_base_url_option_passed_to_client():
+    """When base_url is set via options, it is forwarded to the Anthropic client."""
+    model = llm.get_model("claude-sonnet-4.5")
+
+    fake_message = MagicMock()
+    fake_message.content = [MagicMock(type="text", text="hello")]
+    fake_message.model_dump.return_value = {
+        "content": [{"type": "text", "text": "hello"}],
+        "usage": {"input_tokens": 5, "output_tokens": 3},
+    }
+
+    fake_messages_client = MagicMock()
+    fake_messages_client.create.return_value = fake_message
+
+    fake_client = MagicMock()
+    fake_client.messages = fake_messages_client
+
+    with patch("llm_anthropic.Anthropic") as mock_anthropic:
+        mock_anthropic.return_value = fake_client
+        response = model.prompt(
+            "hello",
+            base_url="https://my-proxy.example.com/v1",
+            key=ANTHROPIC_API_KEY,
+            stream=False,
+        )
+        # Consume the response
+        _ = response.text()
+
+    mock_anthropic.assert_called_once()
+    _, kwargs = mock_anthropic.call_args
+    assert kwargs.get("base_url") == "https://my-proxy.example.com/v1"
+
+
+def test_base_url_option_not_set_uses_model_default():
+    """When base_url option is not set, the model's own base_url is used (None by default)."""
+    model = llm.get_model("claude-sonnet-4.5")
+
+    fake_message = MagicMock()
+    fake_message.content = [MagicMock(type="text", text="hello")]
+    fake_message.model_dump.return_value = {
+        "content": [{"type": "text", "text": "hello"}],
+        "usage": {"input_tokens": 5, "output_tokens": 3},
+    }
+
+    fake_messages_client = MagicMock()
+    fake_messages_client.create.return_value = fake_message
+
+    fake_client = MagicMock()
+    fake_client.messages = fake_messages_client
+
+    with patch("llm_anthropic.Anthropic") as mock_anthropic:
+        mock_anthropic.return_value = fake_client
+        response = model.prompt(
+            "hello",
+            key=ANTHROPIC_API_KEY,
+            stream=False,
+        )
+        _ = response.text()
+
+    mock_anthropic.assert_called_once()
+    _, kwargs = mock_anthropic.call_args
+    assert kwargs.get("base_url") is None


### PR DESCRIPTION
Adds support for setting a custom Anthropic API base URL via the `-o` CLI flag:

\`\`\`bash
llm -m claude-3-5-sonnet -o base_url https://my-proxy.example.com/v1 "hello"
\`\`\`

This enables users to point at self-hosted Anthropic-compatible endpoints or proxies without modifying code.

Previously `base_url` was only configurable at the model-registration level (passed to `ClaudeMessages()`/`AsyncClaudeMessages()` constructors), not via the CLI. With this change, the option-level value takes precedence over the model-level default when set.

## Changes

- Added `base_url: Optional[str]` field to `ClaudeOptions`
- Both `ClaudeMessages.execute` and `AsyncClaudeMessages.execute` now use `prompt.options.base_url` when set, falling back to `self.base_url`
- Two unit tests covering the new option (no network calls, uses `unittest.mock.patch`)