### PR TITLE
Add claude-opus-5

### DIFF
--- a/llm_anthropic.py
+++ b/llm_anthropic.py
@@ -374,6 +374,30 @@ def register_models(register):
         ),
         aliases=("claude-sonnet-5",),
     )
+    # claude-opus-5
+    register(
+        ClaudeMessages(
+            "claude-opus-5",
+            supports_pdf=True,
+            supports_thinking=True,
+            supports_thinking_effort=True,
+            supports_adaptive_thinking=True,
+            supports_web_search=True,
+            use_structured_outputs=True,
+            default_max_tokens=128000,
+        ),
+        AsyncClaudeMessages(
+            "claude-opus-5",
+            supports_pdf=True,
+            supports_thinking=True,
+            supports_thinking_effort=True,
+            supports_adaptive_thinking=True,
+            supports_web_search=True,
+            use_structured_outputs=True,
+            default_max_tokens=128000,
+        ),
+        aliases=("claude-opus-5",),
+    )
 
 
 class ClaudeOptions(llm.Options):


### PR DESCRIPTION
Adds `claude-opus-5`, which was the one current Anthropic model the plugin was missing —
`claude-fable-5` and `claude-sonnet-5` are both already registered.

Capabilities are copied from the `claude-opus-4-8` block, since Opus 5 is its direct
successor and shares the same surface: adaptive thinking, effort levels through `max`,
web search, structured outputs, PDF input, and 128k max output.

```bash
llm -m claude-opus-5 'Fun facts about walruses'
llm -m claude-opus-5 -o thinking 1 -o thinking_effort high 'Solve this step by step: ...'
```

Verified:

- `llm models` lists `Anthropic Messages: anthropic/claude-opus-5 (aliases: claude-opus-5)`
- `pytest` — 34 passed. `test_46_max_effort_opus_only` fails for me, but it fails the
  same way on a clean checkout (it wants a real API key), so it looks unrelated to this
  change.

No new cassettes, since this only touches model registration.

Written with Claude Code; I reviewed it and ran the checks above.
