### PR TITLE
Pass temperature/top_p/top_k via extra_body, and only when set

### DIFF
--- a/llm_anthropic.py
+++ b/llm_anthropic.py
@@ -17,7 +17,6 @@ from urllib.parse import urlsplit
 from pydantic import Field, field_validator, model_validator
 
 DEFAULT_THINKING_TOKENS = 1024
-DEFAULT_TEMPERATURE = 1.0
 MCP_BETA = "mcp-client-2025-11-20"
 
 
@@ -1158,17 +1157,20 @@ class _Shared:
         if prompt.options.user_id:
             kwargs["metadata"] = {"user_id": prompt.options.user_id}
 
+        # anthropic>=1.0 removed temperature/top_p/top_k from the SDK method
+        # signatures (passing them is a TypeError). The API still accepts them
+        # on models that support sampling parameters, so pass them through
+        # extra_body - and only when explicitly requested, because newer
+        # models (Opus 4.7+, Sonnet 5) reject sampling parameters with a 400.
+        sampling = {}
         if prompt.options.top_p:
-            kwargs["top_p"] = prompt.options.top_p
-        else:
-            kwargs["temperature"] = (
-                prompt.options.temperature
-                if prompt.options.temperature is not None
-                else DEFAULT_TEMPERATURE
-            )
-
+            sampling["top_p"] = prompt.options.top_p
+        elif prompt.options.temperature is not None:
+            sampling["temperature"] = prompt.options.temperature
         if prompt.options.top_k:
-            kwargs["top_k"] = prompt.options.top_k
+            sampling["top_k"] = prompt.options.top_k
+        if sampling:
+            kwargs.setdefault("extra_body", {}).update(sampling)
 
         system = self._extract_system(prompt)
         if system:
@@ -1240,7 +1242,9 @@ class _Shared:
         if max_tokens > 64000 and not self.supports_adaptive_thinking:
             betas.append("output-128k-2025-02-19")
             if "thinking" in kwargs:
-                kwargs["extra_body"] = {"thinking": kwargs.pop("thinking")}
+                kwargs.setdefault("extra_body", {})["thinking"] = kwargs.pop(
+                    "thinking"
+                )
 
         # Check if we should use new structured outputs
         use_structured_outputs = prompt.schema and self.use_structured_outputs

--- a/tests/test_anthropic.py
+++ b/tests/test_anthropic.py
@@ -400,6 +400,38 @@ def test_fast_mode_off_by_default():
     assert "betas" not in kwargs
 
 
+def test_sampling_options_not_sent_by_default():
+    # anthropic>=1.0 removed temperature/top_p/top_k from the SDK method
+    # signatures, and newer models reject them - so nothing is sent unless
+    # the user explicitly sets an option
+    model = llm.get_model("claude-sonnet-4.6")
+    prompt = llm.Prompt("Hi", model, options=model.Options())
+    kwargs = model.build_kwargs(prompt, None)
+    assert "temperature" not in kwargs
+    assert "top_p" not in kwargs
+    assert "top_k" not in kwargs
+    assert "extra_body" not in kwargs
+
+
+def test_sampling_options_sent_via_extra_body():
+    model = llm.get_model("claude-sonnet-4.6")
+    prompt = llm.Prompt(
+        "Hi", model, options=model.Options(temperature=0.2, top_k=5)
+    )
+    kwargs = model.build_kwargs(prompt, None)
+    assert "temperature" not in kwargs
+    assert "top_k" not in kwargs
+    assert kwargs["extra_body"] == {"temperature": 0.2, "top_k": 5}
+
+    # top_p takes precedence over temperature (the options validator
+    # currently requires temperature == 1.0 when top_p is set)
+    prompt = llm.Prompt(
+        "Hi", model, options=model.Options(temperature=1.0, top_p=0.9)
+    )
+    kwargs = model.build_kwargs(prompt, None)
+    assert kwargs["extra_body"] == {"top_p": 0.9}
+
+
 def test_opus_5_registered():
     model = llm.get_model("claude-opus-5")
     assert model.model_id == "anthropic/claude-opus-5"


### PR DESCRIPTION
anthropic 1.0.0 (released 2026-08-20) removed the temperature, top_p and top_k keyword arguments from Messages.create() / .stream(), so with the current anthropic>=0.96.0 pin every prompt now fails before any request is made:

    TypeError: Messages.stream() got an unexpected keyword argument 'temperature'

The API still accepts these parameters on models that support sampling options, so send them through extra_body instead - and only when the user explicitly sets one. Previously temperature=1.0 was always sent; omitting it is equivalent (1.0 is the API default) and avoids sending a sampling parameter to the models that reject non-default values.

Also make the existing extra_body write for the 128K-output beta merge rather than overwrite, and drop the now-unused DEFAULT_TEMPERATURE.

Works with both anthropic<1 and anthropic>=1.0. Adds build_kwargs tests for the default and explicit cases.