### PR TITLE
Support anthropic>=1 by using extra_body for model parameters

### DIFF
--- a/llm_anthropic.py
+++ b/llm_anthropic.py
@@ -1158,17 +1158,23 @@ class _Shared:
         if prompt.options.user_id:
             kwargs["metadata"] = {"user_id": prompt.options.user_id}
 
+        # anthropic>=1 removed temperature/top_p/top_k from the method
+        # signatures; the API still accepts them, so send via extra_body
+        extra_body = {}
         if prompt.options.top_p:
-            kwargs["top_p"] = prompt.options.top_p
+            extra_body["top_p"] = prompt.options.top_p
         else:
-            kwargs["temperature"] = (
+            extra_body["temperature"] = (
                 prompt.options.temperature
                 if prompt.options.temperature is not None
                 else DEFAULT_TEMPERATURE
             )
 
         if prompt.options.top_k:
-            kwargs["top_k"] = prompt.options.top_k
+            extra_body["top_k"] = prompt.options.top_k
+
+        if extra_body:
+            kwargs["extra_body"] = extra_body
 
         system = self._extract_system(prompt)
         if system:
@@ -1240,7 +1246,7 @@ class _Shared:
         if max_tokens > 64000 and not self.supports_adaptive_thinking:
             betas.append("output-128k-2025-02-19")
             if "thinking" in kwargs:
-                kwargs["extra_body"] = {"thinking": kwargs.pop("thinking")}
+                kwargs.setdefault("extra_body", {})["thinking"] = kwargs.pop("thinking")
 
         # Check if we should use new structured outputs
         use_structured_outputs = prompt.schema and self.use_structured_outputs

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ requires-python = ">=3.10"
 classifiers = []
 dependencies = [
     "llm>=0.32",
-    "anthropic>=0.96.0",
+    "anthropic>=1,<2",
 ]
 
 [project.urls]
@@ -22,7 +22,15 @@ CI = "https://github.com/simonw/llm-anthropic/actions"
 anthropic = "llm_anthropic"
 
 [dependency-groups]
-dev = ["pytest", "pytest-recording", "pytest-asyncio", "cogapp", "inline-snapshot[black]"]
+dev = [
+    "pytest",
+    "pytest-recording",
+    # vcrpy 8.3+ can record/replay httpx2, used by anthropic>=1
+    "vcrpy>=8.3",
+    "pytest-asyncio",
+    "cogapp",
+    "inline-snapshot[black]",
+]
 
 [tool.uv]
 package = true


### PR DESCRIPTION
> Upgrade to anthropic>=1 - read https://raw.githubusercontent.com/anthropics/anthropic-sdk-python/refs/heads/main/MIGRATION.md and get the tests passing

<details><summary>Fable 5 PR</summary>

## Summary

Updates the Anthropic API integration to support anthropic>=1, which removed `temperature`, `top_p`, and `top_k` from method signatures. These parameters are now passed via the `extra_body` parameter instead.

## Key Changes
- Migrated `temperature`, `top_p`, and `top_k` parameters from direct `kwargs` to `extra_body` dict to comply with anthropic>=1 API changes
- Updated `extra_body` handling for the `thinking` parameter to use `setdefault()` to avoid overwriting existing `extra_body` values
- Updated dependency constraint from `anthropic>=0.96.0` to `anthropic>=1,<2`
- Added `vcrpy>=8.3` to dev dependencies to support recording/replaying httpx2 requests used by anthropic>=1

## Implementation Details
- Parameters are collected in an `extra_body` dict and only added to `kwargs` if non-empty
- The `thinking` parameter handling was refactored to safely merge with any existing `extra_body` dict using `setdefault()`
- This maintains backward compatibility with the API while adapting to the new SDK structure

</details>

https://claude.ai/code/session_01G3SA94Qx13c42KV1YiNejF