### PR TITLE
Preserve omitted and redacted_thinking blocks in Anthropic reasoning

### DIFF
--- a/llm_anthropic.py
+++ b/llm_anthropic.py
@@ -911,6 +911,20 @@ class _Shared:
             tool_name=block_type.removesuffix("_tool_result"),
         )
 
+    def _block_part_index(self, chunk) -> Optional[int]:
+        """Explicit StreamEvent part_index for an Anthropic content block.
+
+        Each Anthropic block index gets its own part index so that
+        consecutive thinking / redacted_thinking blocks assemble into
+        distinct ReasoningParts instead of merging - merging would
+        concatenate their text and keep only the last signature, and
+        Anthropic rejects continuations whose thinking blocks don't
+        match what the model generated. Offset by 1 so the prefill
+        text event can use part_index 0 without colliding.
+        """
+        index = getattr(chunk, "index", None)
+        return None if index is None else index + 1
+
     def _apply_container(self, message_dict, container):
         """Store the code execution container on the response JSON.
 
@@ -963,6 +977,14 @@ class _Shared:
             block: Dict[str, Any] = {"type": "text", "text": part.text}
             return block
         if isinstance(part, ReasoningPart):
+            if (
+                isinstance(anthropic_pm, dict)
+                and anthropic_pm.get("type") == "redacted_thinking"
+                and anthropic_pm.get("data")
+            ):
+                # Safety-redacted reasoning: the opaque data must be
+                # replayed byte-for-byte as a redacted_thinking block.
+                return {"type": "redacted_thinking", "data": anthropic_pm["data"]}
             block = {"type": "thinking", "thinking": part.text}
             # Anthropic signed-thinking requires the signature echoed back.
             sig = (
@@ -1351,12 +1373,15 @@ class ClaudeMessages(_Shared, llm.KeyModel):
             container = None
 
             if prefill_text:
-                yield StreamEvent(type="text", chunk=prefill_text)
+                # part_index 0 is reserved for the prefill so it can
+                # never collide with a content block's explicit index.
+                yield StreamEvent(type="text", chunk=prefill_text, part_index=0)
 
             for chunk in stream_obj:
                 if chunk.type == "content_block_start":
                     block = chunk.content_block
                     block_type = getattr(block, "type", None)
+                    block_part_index = self._block_part_index(chunk)
                     current_block_id = getattr(block, "id", None)
                     current_block_name = getattr(block, "name", None)
                     is_server_tool = block_type in (
@@ -1364,7 +1389,23 @@ class ClaudeMessages(_Shared, llm.KeyModel):
                         "mcp_tool_use",
                     ) or (block_type or "").endswith("_tool_result")
 
-                    if block_type in (
+                    if block_type == "redacted_thinking":
+                        # The opaque block arrives complete on
+                        # content_block_start; preserve it as a
+                        # metadata-only reasoning part so it replays
+                        # unchanged in continuation requests.
+                        yield StreamEvent(
+                            type="reasoning",
+                            chunk="",
+                            part_index=block_part_index,
+                            provider_metadata={
+                                "anthropic": {
+                                    "type": "redacted_thinking",
+                                    "data": getattr(block, "data", ""),
+                                }
+                            },
+                        )
+                    elif block_type in (
                         "tool_use",
                         "server_tool_use",
                         "mcp_tool_use",
@@ -1372,6 +1413,7 @@ class ClaudeMessages(_Shared, llm.KeyModel):
                         yield StreamEvent(
                             type="tool_call_name",
                             chunk=current_block_name or "",
+                            part_index=block_part_index,
                             tool_call_id=current_block_id,
                             server_executed=(block_type != "tool_use"),
                             provider_metadata=(
@@ -1388,28 +1430,41 @@ class ClaudeMessages(_Shared, llm.KeyModel):
                         )
                     elif block_type and block_type.endswith("_tool_result"):
                         # Content is available inline on content_block_start
-                        yield self._server_tool_result_event(block_type, block)
+                        event = self._server_tool_result_event(block_type, block)
+                        event.part_index = block_part_index
+                        yield event
 
                 elif chunk.type == "content_block_delta":
                     delta = chunk.delta
                     delta_type = getattr(delta, "type", None)
+                    block_part_index = self._block_part_index(chunk)
 
                     if delta_type == "thinking_delta":
-                        yield StreamEvent(type="reasoning", chunk=delta.thinking)
+                        yield StreamEvent(
+                            type="reasoning",
+                            chunk=delta.thinking,
+                            part_index=block_part_index,
+                        )
                     elif delta_type == "signature_delta":
                         yield StreamEvent(
                             type="reasoning",
                             chunk="",
+                            part_index=block_part_index,
                             provider_metadata={
                                 "anthropic": {"signature": delta.signature}
                             },
                         )
                     elif delta_type == "text_delta":
-                        yield StreamEvent(type="text", chunk=delta.text)
+                        yield StreamEvent(
+                            type="text",
+                            chunk=delta.text,
+                            part_index=block_part_index,
+                        )
                     elif delta_type == "input_json_delta":
                         yield StreamEvent(
                             type="tool_call_args",
                             chunk=delta.partial_json,
+                            part_index=block_part_index,
                             tool_call_id=current_block_id,
                             server_executed=is_server_tool,
                         )
@@ -1453,12 +1508,15 @@ class AsyncClaudeMessages(_Shared, llm.AsyncKeyModel):
             container = None
 
             if prefill_text:
-                yield StreamEvent(type="text", chunk=prefill_text)
+                # part_index 0 is reserved for the prefill so it can
+                # never collide with a content block's explicit index.
+                yield StreamEvent(type="text", chunk=prefill_text, part_index=0)
 
             async for chunk in stream_obj:
                 if chunk.type == "content_block_start":
                     block = chunk.content_block
                     block_type = getattr(block, "type", None)
+                    block_part_index = self._block_part_index(chunk)
                     current_block_id = getattr(block, "id", None)
                     current_block_name = getattr(block, "name", None)
                     is_server_tool = block_type in (
@@ -1466,7 +1524,23 @@ class AsyncClaudeMessages(_Shared, llm.AsyncKeyModel):
                         "mcp_tool_use",
                     ) or (block_type or "").endswith("_tool_result")
 
-                    if block_type in (
+                    if block_type == "redacted_thinking":
+                        # The opaque block arrives complete on
+                        # content_block_start; preserve it as a
+                        # metadata-only reasoning part so it replays
+                        # unchanged in continuation requests.
+                        yield StreamEvent(
+                            type="reasoning",
+                            chunk="",
+                            part_index=block_part_index,
+                            provider_metadata={
+                                "anthropic": {
+                                    "type": "redacted_thinking",
+                                    "data": getattr(block, "data", ""),
+                                }
+                            },
+                        )
+                    elif block_type in (
                         "tool_use",
                         "server_tool_use",
                         "mcp_tool_use",
@@ -1474,6 +1548,7 @@ class AsyncClaudeMessages(_Shared, llm.AsyncKeyModel):
                         yield StreamEvent(
                             type="tool_call_name",
                             chunk=current_block_name or "",
+                            part_index=block_part_index,
                             tool_call_id=current_block_id,
                             server_executed=(block_type != "tool_use"),
                             provider_metadata=(
@@ -1489,28 +1564,41 @@ class AsyncClaudeMessages(_Shared, llm.AsyncKeyModel):
                             ),
                         )
                     elif block_type and block_type.endswith("_tool_result"):
-                        yield self._server_tool_result_event(block_type, block)
+                        event = self._server_tool_result_event(block_type, block)
+                        event.part_index = block_part_index
+                        yield event
 
                 elif chunk.type == "content_block_delta":
                     delta = chunk.delta
                     delta_type = getattr(delta, "type", None)
+                    block_part_index = self._block_part_index(chunk)
 
                     if delta_type == "thinking_delta":
-                        yield StreamEvent(type="reasoning", chunk=delta.thinking)
+                        yield StreamEvent(
+                            type="reasoning",
+                            chunk=delta.thinking,
+                            part_index=block_part_index,
+                        )
                     elif delta_type == "signature_delta":
                         yield StreamEvent(
                             type="reasoning",
                             chunk="",
+                            part_index=block_part_index,
                             provider_metadata={
                                 "anthropic": {"signature": delta.signature}
                             },
                         )
                     elif delta_type == "text_delta":
-                        yield StreamEvent(type="text", chunk=delta.text)
+                        yield StreamEvent(
+                            type="text",
+                            chunk=delta.text,
+                            part_index=block_part_index,
+                        )
                     elif delta_type == "input_json_delta":
                         yield StreamEvent(
                             type="tool_call_args",
                             chunk=delta.partial_json,
+                            part_index=block_part_index,
                             tool_call_id=current_block_id,
                             server_executed=is_server_tool,
                         )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ license = "Apache-2.0"
 requires-python = ">=3.10"
 classifiers = []
 dependencies = [
-    "llm>=0.32",
+    "llm>=0.33",
     "anthropic>=1,<2",
 ]
 

--- a/tests/test_anthropic.py
+++ b/tests/test_anthropic.py
@@ -1693,3 +1693,392 @@ def test_thinking_effort_still_works():
     kwargs = model.build_kwargs(prompt, None)
     assert kwargs["thinking"] == {"type": "adaptive"}
     assert kwargs["output_config"]["effort"] == "max"
+
+
+# --- Preserving omitted and redacted_thinking blocks (issue #81) ----------
+#
+# Anthropic requires every thinking block - visible, omitted (empty text
+# plus signature) and redacted_thinking (opaque data) - to be replayed
+# complete, unmodified and in order during tool-use continuations.
+# These tests drive execute() with a faked Anthropic stream and check
+# the assembled parts and the blocks a continuation request would send.
+
+
+def _thinking_stream_chunks():
+    """Visible thinking, redacted_thinking, second visible thinking
+    (adjacent same-kind blocks must stay distinct), then a tool call."""
+    from types import SimpleNamespace as ns
+
+    return [
+        ns(
+            type="content_block_start",
+            index=0,
+            content_block=ns(type="thinking", thinking="", signature=""),
+        ),
+        ns(
+            type="content_block_delta",
+            index=0,
+            delta=ns(type="thinking_delta", thinking="first thoughts"),
+        ),
+        ns(
+            type="content_block_delta",
+            index=0,
+            delta=ns(type="signature_delta", signature="SIG-0"),
+        ),
+        ns(type="content_block_stop", index=0),
+        ns(
+            type="content_block_start",
+            index=1,
+            content_block=ns(type="redacted_thinking", data="OPAQUE-1"),
+        ),
+        ns(type="content_block_stop", index=1),
+        ns(
+            type="content_block_start",
+            index=2,
+            content_block=ns(type="thinking", thinking="", signature=""),
+        ),
+        ns(
+            type="content_block_delta",
+            index=2,
+            delta=ns(type="thinking_delta", thinking="second thoughts"),
+        ),
+        ns(
+            type="content_block_delta",
+            index=2,
+            delta=ns(type="signature_delta", signature="SIG-2"),
+        ),
+        ns(type="content_block_stop", index=2),
+        ns(
+            type="content_block_start",
+            index=3,
+            content_block=ns(type="tool_use", id="call-1", name="clock", input={}),
+        ),
+        ns(
+            type="content_block_delta",
+            index=3,
+            delta=ns(type="input_json_delta", partial_json="{}"),
+        ),
+        ns(type="content_block_stop", index=3),
+    ]
+
+
+_THINKING_FINAL_MESSAGE = {
+    "content": [
+        {"type": "thinking", "thinking": "first thoughts", "signature": "SIG-0"},
+        {"type": "redacted_thinking", "data": "OPAQUE-1"},
+        {"type": "thinking", "thinking": "second thoughts", "signature": "SIG-2"},
+        {"type": "tool_use", "id": "call-1", "name": "clock", "input": {}},
+    ],
+    "usage": {"input_tokens": 5, "output_tokens": 10},
+}
+
+
+def _omitted_stream_chunks():
+    """display: omitted - empty thinking block, signature only, then text."""
+    from types import SimpleNamespace as ns
+
+    return [
+        ns(
+            type="content_block_start",
+            index=0,
+            content_block=ns(type="thinking", thinking="", signature=""),
+        ),
+        ns(
+            type="content_block_delta",
+            index=0,
+            delta=ns(type="signature_delta", signature="SIG-OMITTED"),
+        ),
+        ns(type="content_block_stop", index=0),
+        ns(
+            type="content_block_start",
+            index=1,
+            content_block=ns(type="text", text=""),
+        ),
+        ns(
+            type="content_block_delta",
+            index=1,
+            delta=ns(type="text_delta", text="Hi there"),
+        ),
+        ns(type="content_block_stop", index=1),
+    ]
+
+
+_OMITTED_FINAL_MESSAGE = {
+    "content": [
+        {"type": "thinking", "thinking": "", "signature": "SIG-OMITTED"},
+        {"type": "text", "text": "Hi there"},
+    ],
+    "usage": {"input_tokens": 5, "output_tokens": 10},
+}
+
+
+def _patch_fake_stream(monkeypatch, chunks, final_message, asynchronous=False):
+    from types import SimpleNamespace
+    import copy
+
+    class FakeStream:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, exc_type, exc_value, traceback):
+            pass
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, exc_type, exc_value, traceback):
+            pass
+
+        def __iter__(self):
+            return iter(chunks)
+
+        def __aiter__(self):
+            async def events():
+                for chunk in chunks:
+                    yield chunk
+
+            return events()
+
+        def _final(self):
+            return SimpleNamespace(model_dump=lambda: copy.deepcopy(final_message))
+
+        def get_final_message(self):
+            return self._final()
+
+    class FakeAsyncStream(FakeStream):
+        async def get_final_message(self):
+            return self._final()
+
+    class FakeMessages:
+        def stream(self, **kwargs):
+            return FakeAsyncStream() if asynchronous else FakeStream()
+
+    messages = FakeMessages()
+    client = SimpleNamespace(messages=messages, beta=SimpleNamespace(messages=messages))
+    name = "AsyncAnthropic" if asynchronous else "Anthropic"
+    monkeypatch.setattr(llm_anthropic, name, lambda **kwargs: client)
+
+
+def _assert_thinking_sequence_preserved(model, messages, text):
+    from llm.parts import ReasoningPart
+
+    assert "first thoughts" not in text
+    assert "OPAQUE-1" not in text
+    assert "SIG-0" not in text
+
+    assistant_messages = [m for m in messages if m.role == "assistant"]
+    reasoning = [
+        part
+        for message in assistant_messages
+        for part in message.parts
+        if isinstance(part, ReasoningPart)
+    ]
+    assert [part.to_dict() for part in reasoning] == [
+        {
+            "type": "reasoning",
+            "text": "first thoughts",
+            "provider_metadata": {"anthropic": {"signature": "SIG-0"}},
+        },
+        {
+            "type": "reasoning",
+            "text": "",
+            "provider_metadata": {
+                "anthropic": {"type": "redacted_thinking", "data": "OPAQUE-1"}
+            },
+        },
+        {
+            "type": "reasoning",
+            "text": "second thoughts",
+            "provider_metadata": {"anthropic": {"signature": "SIG-2"}},
+        },
+    ]
+    # None of the opaque parts are hoisted or reordered
+    assert not any(part.redacted for part in reasoning)
+
+    # A continuation request must replay the complete original
+    # thinking-block sequence before the tool_use block.
+    blocks = [
+        block
+        for message in assistant_messages
+        for block in model._message_to_blocks(message)
+    ]
+    assert blocks == [
+        {"type": "thinking", "thinking": "first thoughts", "signature": "SIG-0"},
+        {"type": "redacted_thinking", "data": "OPAQUE-1"},
+        {"type": "thinking", "thinking": "second thoughts", "signature": "SIG-2"},
+        {"type": "tool_use", "id": "call-1", "name": "clock", "input": {}},
+    ]
+
+
+def test_redacted_thinking_stream_preserved(monkeypatch):
+    _patch_fake_stream(monkeypatch, _thinking_stream_chunks(), _THINKING_FINAL_MESSAGE)
+    model = llm.get_model("claude-opus-5")
+    response = model.prompt("hi", key="sk-test")
+    _assert_thinking_sequence_preserved(model, response.messages(), response.text())
+
+
+def test_redacted_thinking_no_stream_preserved(monkeypatch):
+    _patch_fake_stream(monkeypatch, _thinking_stream_chunks(), _THINKING_FINAL_MESSAGE)
+    model = llm.get_model("claude-opus-5")
+    response = model.prompt("hi", stream=False, key="sk-test")
+    _assert_thinking_sequence_preserved(model, response.messages(), response.text())
+
+
+@pytest.mark.asyncio
+async def test_async_redacted_thinking_stream_preserved(monkeypatch):
+    _patch_fake_stream(
+        monkeypatch,
+        _thinking_stream_chunks(),
+        _THINKING_FINAL_MESSAGE,
+        asynchronous=True,
+    )
+    model = llm.get_async_model("claude-opus-5")
+    response = await model.prompt("hi", key="sk-test")
+    text = await response.text()
+    _assert_thinking_sequence_preserved(model, await response.messages(), text)
+
+
+@pytest.mark.asyncio
+async def test_async_redacted_thinking_no_stream_preserved(monkeypatch):
+    _patch_fake_stream(
+        monkeypatch,
+        _thinking_stream_chunks(),
+        _THINKING_FINAL_MESSAGE,
+        asynchronous=True,
+    )
+    model = llm.get_async_model("claude-opus-5")
+    response = await model.prompt("hi", stream=False, key="sk-test")
+    text = await response.text()
+    _assert_thinking_sequence_preserved(model, await response.messages(), text)
+
+
+def _assert_omitted_signature_preserved(model, messages, text):
+    from llm.parts import ReasoningPart
+
+    assert text == "Hi there"
+
+    assistant_messages = [m for m in messages if m.role == "assistant"]
+    reasoning = [
+        part
+        for message in assistant_messages
+        for part in message.parts
+        if isinstance(part, ReasoningPart)
+    ]
+    assert [part.to_dict() for part in reasoning] == [
+        {
+            "type": "reasoning",
+            "text": "",
+            "provider_metadata": {"anthropic": {"signature": "SIG-OMITTED"}},
+        }
+    ]
+    blocks = [
+        block
+        for message in assistant_messages
+        for block in model._message_to_blocks(message)
+    ]
+    assert blocks == [
+        {"type": "thinking", "thinking": "", "signature": "SIG-OMITTED"},
+        {"type": "text", "text": "Hi there"},
+    ]
+
+
+def test_omitted_thinking_stream_preserved(monkeypatch):
+    _patch_fake_stream(monkeypatch, _omitted_stream_chunks(), _OMITTED_FINAL_MESSAGE)
+    model = llm.get_model("claude-opus-5")
+    response = model.prompt("hi", key="sk-test")
+    _assert_omitted_signature_preserved(model, response.messages(), response.text())
+
+
+@pytest.mark.asyncio
+async def test_async_omitted_thinking_stream_preserved(monkeypatch):
+    _patch_fake_stream(
+        monkeypatch,
+        _omitted_stream_chunks(),
+        _OMITTED_FINAL_MESSAGE,
+        asynchronous=True,
+    )
+    model = llm.get_async_model("claude-opus-5")
+    response = await model.prompt("hi", key="sk-test")
+    text = await response.text()
+    _assert_omitted_signature_preserved(model, await response.messages(), text)
+
+
+def test_redacted_thinking_survives_log_store_round_trip(monkeypatch):
+    """The content-addressed message store persists reasoning parts with
+    their provider_metadata, so a conversation reloaded by llm -c can
+    replay the exact thinking-block sequence after a CLI restart."""
+    import sqlite_utils
+    from llm.logs import LogStore
+    from llm.migrations import migrate
+
+    _patch_fake_stream(monkeypatch, _thinking_stream_chunks(), _THINKING_FINAL_MESSAGE)
+    model = llm.get_model("claude-opus-5")
+    response = model.prompt("hi", key="sk-test")
+    text = response.text()
+
+    db = sqlite_utils.Database(memory=True)
+    migrate(db)
+    store = LogStore(db)
+    turn_id = store.log(response)
+    thread_id = list(db.query("select thread_id from turns where id = ?", [turn_id]))[
+        0
+    ]["thread_id"]
+
+    loaded_messages = store.thread_messages(thread_id)
+    _assert_thinking_sequence_preserved(model, loaded_messages, text)
+
+
+def test_build_messages_redacted_thinking_round_trips():
+    """Redacted metadata reconstructs an exact redacted_thinking block,
+    in position, and ordinary reasoning is never turned into one."""
+    from llm import assistant, user
+    from llm.parts import ReasoningPart, ToolCallPart
+
+    msgs = _build_messages_for(
+        {
+            "messages": [
+                user("q"),
+                assistant(
+                    ReasoningPart(
+                        text="visible",
+                        provider_metadata={"anthropic": {"signature": "sig-1"}},
+                    ),
+                    ReasoningPart(
+                        text="",
+                        provider_metadata={
+                            "anthropic": {
+                                "type": "redacted_thinking",
+                                "data": "opaque-data",
+                            }
+                        },
+                    ),
+                    ReasoningPart(
+                        text="",
+                        provider_metadata={"anthropic": {"signature": "sig-2"}},
+                    ),
+                    ToolCallPart(name="clock", arguments={}, tool_call_id="c1"),
+                ),
+            ]
+        }
+    )
+    assert msgs[1]["content"] == [
+        {"type": "thinking", "thinking": "visible", "signature": "sig-1"},
+        {"type": "redacted_thinking", "data": "opaque-data"},
+        {"type": "thinking", "thinking": "", "signature": "sig-2"},
+        {"type": "tool_use", "id": "c1", "name": "clock", "input": {}},
+    ]
+
+
+def test_build_messages_plain_reasoning_not_invented_as_redacted():
+    from llm import assistant, user
+    from llm.parts import ReasoningPart
+
+    msgs = _build_messages_for(
+        {
+            "messages": [
+                user("q"),
+                assistant(ReasoningPart(text="thoughts", redacted=True)),
+            ]
+        }
+    )
+    assert msgs[1]["content"] == [{"type": "thinking", "thinking": "thoughts"}]


### PR DESCRIPTION
Closes:
- #81

<details><summary>Fable 5 PR</summary>

## What changed

Anthropic requires every thinking block — visible, omitted (empty text plus signature) and `redacted_thinking` (opaque data) — to be replayed complete, unmodified and in order during tool-use continuations ([docs](https://platform.claude.com/docs/en/build-with-claude/thinking#preserving-thinking-blocks)). Two bugs broke that:

- **`redacted_thinking` blocks were dropped entirely.** `content_block_start` handling only recognized tool-use and tool-result block types, so the opaque block never became a part and never replayed. Now it emits a metadata-only reasoning event carrying `{"anthropic": {"type": "redacted_thinking", "data": ...}}`, and `_part_to_block()` reconstructs the exact `{"type": "redacted_thinking", "data": ...}` wire block (and never invents one for ordinary reasoning parts).
- **Consecutive thinking blocks merged into one `ReasoningPart`.** Reasoning events carried no `part_index`, so llm's assembler concatenated adjacent blocks' text and kept only the last signature — producing continuation requests the API rejects with a 400, even for two plain visible blocks. Every block-derived `StreamEvent` now gets an explicit `part_index` derived from the Anthropic content block index (`chunk.index + 1`, with 0 reserved for the prefill text event so they can never collide).

Also bumps the dependency floor to `llm>=0.33`: that's where metadata-only reasoning parts survive event assembly (0.32's assembler drops the signature-only parts produced by `display: "omitted"`, which is the default on Claude 5 models).

## Notes for review

- The omitted-thinking case (empty `thinking` + signature) needed no plugin change beyond the version bump — `_part_to_block()` already round-trips it once llm 0.33 keeps the part.
- Sync and async `execute()` receive identical changes.
- New tests fake the Anthropic stream and cover: sync/async × stream/no-stream, distinct in-order parts for a visible → redacted → visible → tool_use sequence, exact continuation blocks, opaque values kept out of `response.text()`, and a `LogStore` save/reload round trip proving the sequence survives `llm -c` after a CLI restart. Two pure `build_messages` tests pin the block reconstruction.
- All 92 tests pass (`uv run pytest`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

</details>